### PR TITLE
Fixes Issue #4 - Resolving Critical Bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ prompts-*.md
 package/
 *.tgz
 .claude-trace/
+/coverage

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Extract and compare system prompts and tools from different Claude Code versions
 
 ## Prerequisites
 
-- Claude Code must be installed locally
-- You must be logged in to Claude Code
-- Note: Each version tested will send a single `-p "hey"` request to Claude, which may incur costs if you're on a pay-per-token plan instead of Claude Max
+- You must be logged in to Claude Code (authentication required for all modes)
+- Claude Code installation is optional if using `--binary-path` with a custom binary
+- Note: Each version tested will send a single haiku request to Claude, which may incur costs if you're on a pay-per-token plan instead of Claude Max
 
 ## Installation
 
@@ -17,26 +17,58 @@ npm install -g @mariozechner/cchistory
 ## Usage
 
 ```bash
-cchistory <version> [--latest]
+cchistory [version] [--latest] [--binary-path <path>] [--claude-args "<args>"]
 ```
 
-Examples:
+### Options
+
+- `version` - NPM version of Claude Code to extract (e.g., `1.0.0`)
+- `--latest` - Extract all versions from the specified version to the latest published version
+- `--binary-path <path>` - Use a custom/local Claude Code binary instead of downloading from npm
+- `--claude-args "<args>"` - Pass additional arguments to Claude Code during execution
+- `--version`, `-v` - Show cchistory version
+- `--help`, `-h` - Show help message
+
+### Examples
+
 ```bash
 # Extract prompts from a single version
 cchistory 1.0.0
 
 # Extract prompts from version 1.0.0 to latest
 cchistory 1.0.0 --latest
+
+# Test a custom/local build of Claude Code
+cchistory --binary-path /path/to/custom/cli.js
+
+# Test with additional Claude Code arguments
+cchistory 1.0.0 --claude-args "--mcp-config /path/to/config.json"
+
+# Combine custom binary with custom arguments
+cchistory --binary-path ./build/cli.js --claude-args "--verbose"
+
+# Pass system prompt modifiers to any version
+cchistory 1.5.0 --claude-args "--append-system-prompt"
 ```
 
 ## How it works
 
+### Standard Mode (NPM versions)
+
 1. Downloads the specified Claude Code version from npm
 2. Patches the version check to prevent auto-updates
 3. Runs the patched version with claude-trace to intercept API requests
-4. Sends a single test message (`-p "hey"`) to trigger an API call
+4. Sends a single test haiku request to trigger an API call
 5. Extracts the system prompt, user message format, and available tools from the intercepted request
 6. Saves the results to `prompts-{version}.md`
+
+### Custom Binary Mode (`--binary-path`)
+
+1. Uses the specified binary directly (skips download and patching)
+2. Runs it with claude-trace to intercept API requests
+3. Sends a single test haiku request to trigger an API call
+4. Extracts the system prompt, user message format, and available tools from the intercepted request
+5. Saves the results to `prompts-custom-{timestamp}.md`
 
 Existing prompt files are automatically skipped to avoid redundant downloads and API calls.
 
@@ -46,3 +78,58 @@ Each `prompts-{version}.md` file contains:
 - **User Message**: The format of user messages sent to Claude
 - **System Prompt**: The system instructions Claude receives
 - **Tools**: Available tools with their descriptions and input schemas (excluding MCP tools)
+
+## Advanced Usage
+
+### Testing Local/Development Builds
+
+The `--binary-path` flag is particularly useful for:
+- Testing local modifications to Claude Code before publishing
+- Comparing development builds against released versions
+- Debugging prompt or tool changes in your fork
+
+```bash
+# Test your local development build
+cchistory --binary-path /path/to/your/fork/cli.js
+
+# Compare with a released version
+cchistory 1.0.0
+# Now you have both prompts-1.0.0.md and prompts-custom-*.md to compare
+```
+
+### Passing Arguments to Claude Code
+
+The `--claude-args` flag allows you to test Claude Code with different configurations:
+
+```bash
+# Test with MCP server configuration
+cchistory 1.5.0 --claude-args "--mcp-config ~/.config/claude/mcp.json"
+
+# Test with verbose logging
+cchistory --binary-path ./build/cli.js --claude-args "--verbose"
+
+# Combine multiple flags
+cchistory 1.0.0 --claude-args "--debug --no-cache"
+```
+
+**Note**: Arguments are parsed safely using shell-quote to prevent command injection. Shell operators and control characters are filtered out.
+
+### Debugging
+
+Enable debug output to see detailed information about the extraction process:
+
+```bash
+DEBUG=1 cchistory 1.0.0
+```
+
+This will show:
+- All API requests found in the claude-trace log
+- Model names and tool counts for each request
+- Full stack traces for any errors
+
+### Security Notes
+
+- All shell commands use proper escaping via the `shell-quote` library
+- The `--claude-args` parameter filters out shell operators for safety
+- Version patching only modifies the version check function (no other code changes)
+- Custom binaries are executed directly without modification

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,16 @@
 			"version": "1.1.9",
 			"license": "MIT",
 			"dependencies": {
-				"chalk": "^5.5.0"
+				"chalk": "^5.5.0",
+				"shell-quote": "^1.8.3"
 			},
 			"bin": {
-				"cchistory": "dist/prompts.js"
+				"cchistory": "dist/index.js"
 			},
 			"devDependencies": {
 				"@biomejs/biome": "^2.1.4",
 				"@types/node": "^22.10.5",
+				"@types/shell-quote": "^1.7.5",
 				"husky": "^9.1.7",
 				"tsx": "^4.20.3",
 				"typescript": "^5.9.2"
@@ -640,6 +642,13 @@
 				"undici-types": "~6.21.0"
 			}
 		},
+		"node_modules/@types/shell-quote": {
+			"version": "1.7.5",
+			"resolved": "https://registry.npmjs.org/@types/shell-quote/-/shell-quote-1.7.5.tgz",
+			"integrity": "sha512-+UE8GAGRPbJVQDdxi16dgadcBfQ+KG2vgZhV1+3A1XmHbmwcdwhCUwIdy+d3pAGrbvgRoVSjeI9vOWyq376Yzw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/chalk": {
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.5.0.tgz",
@@ -746,6 +755,18 @@
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+			}
+		},
+		"node_modules/shell-quote": {
+			"version": "1.8.3",
+			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+			"integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/tsx": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,12 +19,89 @@
 				"@biomejs/biome": "^2.1.4",
 				"@types/node": "^22.10.5",
 				"@types/shell-quote": "^1.7.5",
+				"@vitest/coverage-v8": "^3.2.4",
 				"husky": "^9.1.7",
+				"memfs": "^4.49.0",
 				"tsx": "^4.20.3",
-				"typescript": "^5.9.2"
+				"typescript": "^5.9.2",
+				"vitest": "^3.2.4"
 			},
 			"engines": {
 				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@ampproject/remapping": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+			"integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@jridgewell/gen-mapping": "^0.3.5",
+				"@jridgewell/trace-mapping": "^0.3.24"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@babel/helper-string-parser": {
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+			"integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-validator-identifier": {
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+			"integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/parser": {
+			"version": "7.28.4",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz",
+			"integrity": "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/types": "^7.28.4"
+			},
+			"bin": {
+				"parser": "bin/babel-parser.js"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@babel/types": {
+			"version": "7.28.4",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
+			"integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-string-parser": "^7.27.1",
+				"@babel/helper-validator-identifier": "^7.27.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@bcoe/v8-coverage": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+			"integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/@biomejs/biome": {
@@ -632,6 +709,535 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/@isaacs/cliui": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+			"integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^5.1.2",
+				"string-width-cjs": "npm:string-width@^4.2.0",
+				"strip-ansi": "^7.0.1",
+				"strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+				"wrap-ansi": "^8.1.0",
+				"wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@istanbuljs/schema": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+			"integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@jridgewell/gen-mapping": {
+			"version": "0.3.13",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+			"integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/sourcemap-codec": "^1.5.0",
+				"@jridgewell/trace-mapping": "^0.3.24"
+			}
+		},
+		"node_modules/@jridgewell/resolve-uri": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+			"integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@jridgewell/sourcemap-codec": {
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+			"integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@jridgewell/trace-mapping": {
+			"version": "0.3.31",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+			"integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/resolve-uri": "^3.1.0",
+				"@jridgewell/sourcemap-codec": "^1.4.14"
+			}
+		},
+		"node_modules/@jsonjoy.com/base64": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/base64/-/base64-1.1.2.tgz",
+			"integrity": "sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/buffers": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-1.2.0.tgz",
+			"integrity": "sha512-6RX+W5a+ZUY/c/7J5s5jK9UinLfJo5oWKh84fb4X0yK2q4WXEWUWZWuEMjvCb1YNUQhEAhUfr5scEGOH7jC4YQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/codegen": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/codegen/-/codegen-1.0.0.tgz",
+			"integrity": "sha512-E8Oy+08cmCf0EK/NMxpaJZmOxPqM+6iSe2S4nlSBrPZOORoDJILxtbSUEDKQyTamm/BVAhIGllOBNU79/dwf0g==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/json-pack": {
+			"version": "1.20.0",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pack/-/json-pack-1.20.0.tgz",
+			"integrity": "sha512-adcXFVorSQULtT4XDL0giRLr2EVGIcyWm6eQKZWTrRA4EEydGOY8QVQtL0PaITQpUyu+lOd/QOicw6vdy1v8QQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@jsonjoy.com/base64": "^1.1.2",
+				"@jsonjoy.com/buffers": "^1.2.0",
+				"@jsonjoy.com/codegen": "^1.0.0",
+				"@jsonjoy.com/json-pointer": "^1.0.2",
+				"@jsonjoy.com/util": "^1.9.0",
+				"hyperdyperid": "^1.2.0",
+				"thingies": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/json-pointer": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pointer/-/json-pointer-1.0.2.tgz",
+			"integrity": "sha512-Fsn6wM2zlDzY1U+v4Nc8bo3bVqgfNTGcn6dMgs6FjrEnt4ZCe60o6ByKRjOGlI2gow0aE/Q41QOigdTqkyK5fg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@jsonjoy.com/codegen": "^1.0.0",
+				"@jsonjoy.com/util": "^1.9.0"
+			},
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/util": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-1.9.0.tgz",
+			"integrity": "sha512-pLuQo+VPRnN8hfPqUTLTHk126wuYdXVxE6aDmjSeV4NCAgyxWbiOIeNJVtID3h1Vzpoi9m4jXezf73I6LgabgQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@jsonjoy.com/buffers": "^1.0.0",
+				"@jsonjoy.com/codegen": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@pkgjs/parseargs": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+			"integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/@rollup/rollup-android-arm-eabi": {
+			"version": "4.52.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.4.tgz",
+			"integrity": "sha512-BTm2qKNnWIQ5auf4deoetINJm2JzvihvGb9R6K/ETwKLql/Bb3Eg2H1FBp1gUb4YGbydMA3jcmQTR73q7J+GAA==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			]
+		},
+		"node_modules/@rollup/rollup-android-arm64": {
+			"version": "4.52.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.52.4.tgz",
+			"integrity": "sha512-P9LDQiC5vpgGFgz7GSM6dKPCiqR3XYN1WwJKA4/BUVDjHpYsf3iBEmVz62uyq20NGYbiGPR5cNHI7T1HqxNs2w==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			]
+		},
+		"node_modules/@rollup/rollup-darwin-arm64": {
+			"version": "4.52.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.52.4.tgz",
+			"integrity": "sha512-QRWSW+bVccAvZF6cbNZBJwAehmvG9NwfWHwMy4GbWi/BQIA/laTIktebT2ipVjNncqE6GLPxOok5hsECgAxGZg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@rollup/rollup-darwin-x64": {
+			"version": "4.52.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.52.4.tgz",
+			"integrity": "sha512-hZgP05pResAkRJxL1b+7yxCnXPGsXU0fG9Yfd6dUaoGk+FhdPKCJ5L1Sumyxn8kvw8Qi5PvQ8ulenUbRjzeCTw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@rollup/rollup-freebsd-arm64": {
+			"version": "4.52.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.52.4.tgz",
+			"integrity": "sha512-xmc30VshuBNUd58Xk4TKAEcRZHaXlV+tCxIXELiE9sQuK3kG8ZFgSPi57UBJt8/ogfhAF5Oz4ZSUBN77weM+mQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			]
+		},
+		"node_modules/@rollup/rollup-freebsd-x64": {
+			"version": "4.52.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.52.4.tgz",
+			"integrity": "sha512-WdSLpZFjOEqNZGmHflxyifolwAiZmDQzuOzIq9L27ButpCVpD7KzTRtEG1I0wMPFyiyUdOO+4t8GvrnBLQSwpw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+			"version": "4.52.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.52.4.tgz",
+			"integrity": "sha512-xRiOu9Of1FZ4SxVbB0iEDXc4ddIcjCv2aj03dmW8UrZIW7aIQ9jVJdLBIhxBI+MaTnGAKyvMwPwQnoOEvP7FgQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm-musleabihf": {
+			"version": "4.52.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.52.4.tgz",
+			"integrity": "sha512-FbhM2p9TJAmEIEhIgzR4soUcsW49e9veAQCziwbR+XWB2zqJ12b4i/+hel9yLiD8pLncDH4fKIPIbt5238341Q==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm64-gnu": {
+			"version": "4.52.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.52.4.tgz",
+			"integrity": "sha512-4n4gVwhPHR9q/g8lKCyz0yuaD0MvDf7dV4f9tHt0C73Mp8h38UCtSCSE6R9iBlTbXlmA8CjpsZoujhszefqueg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm64-musl": {
+			"version": "4.52.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.52.4.tgz",
+			"integrity": "sha512-u0n17nGA0nvi/11gcZKsjkLj1QIpAuPFQbR48Subo7SmZJnGxDpspyw2kbpuoQnyK+9pwf3pAoEXerJs/8Mi9g==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-loong64-gnu": {
+			"version": "4.52.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.52.4.tgz",
+			"integrity": "sha512-0G2c2lpYtbTuXo8KEJkDkClE/+/2AFPdPAbmaHoE870foRFs4pBrDehilMcrSScrN/fB/1HTaWO4bqw+ewBzMQ==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-ppc64-gnu": {
+			"version": "4.52.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.52.4.tgz",
+			"integrity": "sha512-teSACug1GyZHmPDv14VNbvZFX779UqWTsd7KtTM9JIZRDI5NUwYSIS30kzI8m06gOPB//jtpqlhmraQ68b5X2g==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-riscv64-gnu": {
+			"version": "4.52.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.52.4.tgz",
+			"integrity": "sha512-/MOEW3aHjjs1p4Pw1Xk4+3egRevx8Ji9N6HUIA1Ifh8Q+cg9dremvFCUbOX2Zebz80BwJIgCBUemjqhU5XI5Eg==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-riscv64-musl": {
+			"version": "4.52.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.52.4.tgz",
+			"integrity": "sha512-1HHmsRyh845QDpEWzOFtMCph5Ts+9+yllCrREuBR/vg2RogAQGGBRC8lDPrPOMnrdOJ+mt1WLMOC2Kao/UwcvA==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-s390x-gnu": {
+			"version": "4.52.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.52.4.tgz",
+			"integrity": "sha512-seoeZp4L/6D1MUyjWkOMRU6/iLmCU2EjbMTyAG4oIOs1/I82Y5lTeaxW0KBfkUdHAWN7j25bpkt0rjnOgAcQcA==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-x64-gnu": {
+			"version": "4.52.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.4.tgz",
+			"integrity": "sha512-Wi6AXf0k0L7E2gteNsNHUs7UMwCIhsCTs6+tqQ5GPwVRWMaflqGec4Sd8n6+FNFDw9vGcReqk2KzBDhCa1DLYg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-x64-musl": {
+			"version": "4.52.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.52.4.tgz",
+			"integrity": "sha512-dtBZYjDmCQ9hW+WgEkaffvRRCKm767wWhxsFW3Lw86VXz/uJRuD438/XvbZT//B96Vs8oTA8Q4A0AfHbrxP9zw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-openharmony-arm64": {
+			"version": "4.52.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.52.4.tgz",
+			"integrity": "sha512-1ox+GqgRWqaB1RnyZXL8PD6E5f7YyRUJYnCqKpNzxzP0TkaUh112NDrR9Tt+C8rJ4x5G9Mk8PQR3o7Ku2RKqKA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-arm64-msvc": {
+			"version": "4.52.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.52.4.tgz",
+			"integrity": "sha512-8GKr640PdFNXwzIE0IrkMWUNUomILLkfeHjXBi/nUvFlpZP+FA8BKGKpacjW6OUUHaNI6sUURxR2U2g78FOHWQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-ia32-msvc": {
+			"version": "4.52.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.52.4.tgz",
+			"integrity": "sha512-AIy/jdJ7WtJ/F6EcfOb2GjR9UweO0n43jNObQMb6oGxkYTfLcnN7vYYpG+CN3lLxrQkzWnMOoNSHTW54pgbVxw==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-x64-gnu": {
+			"version": "4.52.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.52.4.tgz",
+			"integrity": "sha512-UF9KfsH9yEam0UjTwAgdK0anlQ7c8/pWPU2yVjyWcF1I1thABt6WXE47cI71pGiZ8wGvxohBoLnxM04L/wj8mQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-x64-msvc": {
+			"version": "4.52.4",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.52.4.tgz",
+			"integrity": "sha512-bf9PtUa0u8IXDVxzRToFQKsNCRz9qLYfR/MpECxl4mRoWYjAeFjgxj1XdZr2M/GNVpT05p+LgQOHopYDlUu6/w==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@types/chai": {
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
+			"integrity": "sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/deep-eql": "*"
+			}
+		},
+		"node_modules/@types/deep-eql": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+			"integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/estree": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+			"integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/node": {
 			"version": "22.17.1",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.17.1.tgz",
@@ -649,6 +1255,247 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@vitest/coverage-v8": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
+			"integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@ampproject/remapping": "^2.3.0",
+				"@bcoe/v8-coverage": "^1.0.2",
+				"ast-v8-to-istanbul": "^0.3.3",
+				"debug": "^4.4.1",
+				"istanbul-lib-coverage": "^3.2.2",
+				"istanbul-lib-report": "^3.0.1",
+				"istanbul-lib-source-maps": "^5.0.6",
+				"istanbul-reports": "^3.1.7",
+				"magic-string": "^0.30.17",
+				"magicast": "^0.3.5",
+				"std-env": "^3.9.0",
+				"test-exclude": "^7.0.1",
+				"tinyrainbow": "^2.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"@vitest/browser": "3.2.4",
+				"vitest": "3.2.4"
+			},
+			"peerDependenciesMeta": {
+				"@vitest/browser": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@vitest/expect": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+			"integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/chai": "^5.2.2",
+				"@vitest/spy": "3.2.4",
+				"@vitest/utils": "3.2.4",
+				"chai": "^5.2.0",
+				"tinyrainbow": "^2.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/mocker": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+			"integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/spy": "3.2.4",
+				"estree-walker": "^3.0.3",
+				"magic-string": "^0.30.17"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"msw": "^2.4.9",
+				"vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+			},
+			"peerDependenciesMeta": {
+				"msw": {
+					"optional": true
+				},
+				"vite": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@vitest/pretty-format": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+			"integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tinyrainbow": "^2.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/runner": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+			"integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/utils": "3.2.4",
+				"pathe": "^2.0.3",
+				"strip-literal": "^3.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/snapshot": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+			"integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "3.2.4",
+				"magic-string": "^0.30.17",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/spy": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+			"integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tinyspy": "^4.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/utils": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+			"integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "3.2.4",
+				"loupe": "^3.1.4",
+				"tinyrainbow": "^2.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/ansi-regex": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+			"integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/ansi-styles": {
+			"version": "6.2.3",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+			"integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/assertion-error": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+			"integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/ast-v8-to-istanbul": {
+			"version": "0.3.6",
+			"resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.6.tgz",
+			"integrity": "sha512-9tx1z/7OF/a8EdYL3FKoBhxLf3h3D8fXvuSj0HknsVeli2HE40qbNZxyFhMtnydaRiamwFu9zhb+BsJ5tVPehQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/trace-mapping": "^0.3.31",
+				"estree-walker": "^3.0.3",
+				"js-tokens": "^9.0.1"
+			}
+		},
+		"node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/brace-expansion": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/cac": {
+			"version": "6.7.14",
+			"resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+			"integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/chai": {
+			"version": "5.3.3",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+			"integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"assertion-error": "^2.0.1",
+				"check-error": "^2.1.1",
+				"deep-eql": "^5.0.1",
+				"loupe": "^3.1.0",
+				"pathval": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/chalk": {
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.5.0.tgz",
@@ -660,6 +1507,100 @@
 			"funding": {
 				"url": "https://github.com/chalk/chalk?sponsor=1"
 			}
+		},
+		"node_modules/check-error": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+			"integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 16"
+			}
+		},
+		"node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/cross-spawn": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"path-key": "^3.1.0",
+				"shebang-command": "^2.0.0",
+				"which": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/debug": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/deep-eql": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+			"integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/eastasianwidth": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+			"integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/emoji-regex": {
+			"version": "9.2.2",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+			"integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/es-module-lexer": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+			"integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/esbuild": {
 			"version": "0.25.8",
@@ -703,6 +1644,61 @@
 				"@esbuild/win32-x64": "0.25.8"
 			}
 		},
+		"node_modules/estree-walker": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0"
+			}
+		},
+		"node_modules/expect-type": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
+			"integrity": "sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/fdir": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"peerDependencies": {
+				"picomatch": "^3 || ^4"
+			},
+			"peerDependenciesMeta": {
+				"picomatch": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/foreground-child": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+			"integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"cross-spawn": "^7.0.6",
+				"signal-exit": "^4.0.1"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
 		"node_modules/fsevents": {
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -731,6 +1727,61 @@
 				"url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
 			}
 		},
+		"node_modules/glob": {
+			"version": "10.4.5",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+			"integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"foreground-child": "^3.1.0",
+				"jackspeak": "^3.1.2",
+				"minimatch": "^9.0.4",
+				"minipass": "^7.1.2",
+				"package-json-from-dist": "^1.0.0",
+				"path-scurry": "^1.11.1"
+			},
+			"bin": {
+				"glob": "dist/esm/bin.mjs"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/glob-to-regex.js": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/glob-to-regex.js/-/glob-to-regex.js-1.2.0.tgz",
+			"integrity": "sha512-QMwlOQKU/IzqMUOAZWubUOT8Qft+Y0KQWnX9nK3ch0CJg0tTp4TvGZsTfudYKv2NzoQSyPcnA6TYeIQ3jGichQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/html-escaper": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+			"integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/husky": {
 			"version": "9.1.7",
 			"resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
@@ -747,6 +1798,333 @@
 				"url": "https://github.com/sponsors/typicode"
 			}
 		},
+		"node_modules/hyperdyperid": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/hyperdyperid/-/hyperdyperid-1.2.0.tgz",
+			"integrity": "sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.18"
+			}
+		},
+		"node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/isexe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/istanbul-lib-coverage": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+			"integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/istanbul-lib-report": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+			"integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"istanbul-lib-coverage": "^3.0.0",
+				"make-dir": "^4.0.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/istanbul-lib-source-maps": {
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+			"integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@jridgewell/trace-mapping": "^0.3.23",
+				"debug": "^4.1.1",
+				"istanbul-lib-coverage": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/istanbul-reports": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+			"integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"html-escaper": "^2.0.0",
+				"istanbul-lib-report": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/jackspeak": {
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+			"integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"@isaacs/cliui": "^8.0.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			},
+			"optionalDependencies": {
+				"@pkgjs/parseargs": "^0.11.0"
+			}
+		},
+		"node_modules/js-tokens": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+			"integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/loupe": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+			"integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/lru-cache": {
+			"version": "10.4.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/magic-string": {
+			"version": "0.30.19",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
+			"integrity": "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/sourcemap-codec": "^1.5.5"
+			}
+		},
+		"node_modules/magicast": {
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+			"integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/parser": "^7.25.4",
+				"@babel/types": "^7.25.4",
+				"source-map-js": "^1.2.0"
+			}
+		},
+		"node_modules/make-dir": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+			"integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"semver": "^7.5.3"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/memfs": {
+			"version": "4.49.0",
+			"resolved": "https://registry.npmjs.org/memfs/-/memfs-4.49.0.tgz",
+			"integrity": "sha512-L9uC9vGuc4xFybbdOpRLoOAOq1YEBBsocCs5NVW32DfU+CZWWIn3OVF+lB8Gp4ttBVSMazwrTrjv8ussX/e3VQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@jsonjoy.com/json-pack": "^1.11.0",
+				"@jsonjoy.com/util": "^1.9.0",
+				"glob-to-regex.js": "^1.0.1",
+				"thingies": "^2.5.0",
+				"tree-dump": "^1.0.3",
+				"tslib": "^2.0.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			}
+		},
+		"node_modules/minimatch": {
+			"version": "9.0.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/minipass": {
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+			"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			}
+		},
+		"node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/nanoid": {
+			"version": "3.3.11",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+			"integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"bin": {
+				"nanoid": "bin/nanoid.cjs"
+			},
+			"engines": {
+				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+			}
+		},
+		"node_modules/package-json-from-dist": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+			"integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+			"dev": true,
+			"license": "BlueOak-1.0.0"
+		},
+		"node_modules/path-key": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/path-scurry": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+			"integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"lru-cache": "^10.2.0",
+				"minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/pathe": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/pathval": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+			"integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 14.16"
+			}
+		},
+		"node_modules/picocolors": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/picomatch": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/postcss": {
+			"version": "8.5.6",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+			"integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/postcss/"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/postcss"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"nanoid": "^3.3.11",
+				"picocolors": "^1.1.1",
+				"source-map-js": "^1.2.1"
+			},
+			"engines": {
+				"node": "^10 || ^12 || >=14"
+			}
+		},
 		"node_modules/resolve-pkg-maps": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
@@ -755,6 +2133,84 @@
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+			}
+		},
+		"node_modules/rollup": {
+			"version": "4.52.4",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.4.tgz",
+			"integrity": "sha512-CLEVl+MnPAiKh5pl4dEWSyMTpuflgNQiLGhMv8ezD5W/qP8AKvmYpCOKRRNOh7oRKnauBZ4SyeYkMS+1VSyKwQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "1.0.8"
+			},
+			"bin": {
+				"rollup": "dist/bin/rollup"
+			},
+			"engines": {
+				"node": ">=18.0.0",
+				"npm": ">=8.0.0"
+			},
+			"optionalDependencies": {
+				"@rollup/rollup-android-arm-eabi": "4.52.4",
+				"@rollup/rollup-android-arm64": "4.52.4",
+				"@rollup/rollup-darwin-arm64": "4.52.4",
+				"@rollup/rollup-darwin-x64": "4.52.4",
+				"@rollup/rollup-freebsd-arm64": "4.52.4",
+				"@rollup/rollup-freebsd-x64": "4.52.4",
+				"@rollup/rollup-linux-arm-gnueabihf": "4.52.4",
+				"@rollup/rollup-linux-arm-musleabihf": "4.52.4",
+				"@rollup/rollup-linux-arm64-gnu": "4.52.4",
+				"@rollup/rollup-linux-arm64-musl": "4.52.4",
+				"@rollup/rollup-linux-loong64-gnu": "4.52.4",
+				"@rollup/rollup-linux-ppc64-gnu": "4.52.4",
+				"@rollup/rollup-linux-riscv64-gnu": "4.52.4",
+				"@rollup/rollup-linux-riscv64-musl": "4.52.4",
+				"@rollup/rollup-linux-s390x-gnu": "4.52.4",
+				"@rollup/rollup-linux-x64-gnu": "4.52.4",
+				"@rollup/rollup-linux-x64-musl": "4.52.4",
+				"@rollup/rollup-openharmony-arm64": "4.52.4",
+				"@rollup/rollup-win32-arm64-msvc": "4.52.4",
+				"@rollup/rollup-win32-ia32-msvc": "4.52.4",
+				"@rollup/rollup-win32-x64-gnu": "4.52.4",
+				"@rollup/rollup-win32-x64-msvc": "4.52.4",
+				"fsevents": "~2.3.2"
+			}
+		},
+		"node_modules/semver": {
+			"version": "7.7.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/shebang-command": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"shebang-regex": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/shebang-regex": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/shell-quote": {
@@ -768,6 +2224,297 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
+		},
+		"node_modules/siginfo": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+			"integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/signal-exit": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/source-map-js": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+			"integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/stackback": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+			"integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/std-env": {
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+			"integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/string-width": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+			"integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"eastasianwidth": "^0.2.0",
+				"emoji-regex": "^9.2.2",
+				"strip-ansi": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/string-width-cjs": {
+			"name": "string-width",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/string-width-cjs/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/string-width-cjs/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/string-width-cjs/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strip-ansi": {
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+			"integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
+		"node_modules/strip-ansi-cjs": {
+			"name": "strip-ansi",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strip-literal": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+			"integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"js-tokens": "^9.0.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/antfu"
+			}
+		},
+		"node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/test-exclude": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.1.tgz",
+			"integrity": "sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"@istanbuljs/schema": "^0.1.2",
+				"glob": "^10.4.1",
+				"minimatch": "^9.0.4"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/thingies": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/thingies/-/thingies-2.5.0.tgz",
+			"integrity": "sha512-s+2Bwztg6PhWUD7XMfeYm5qliDdSiZm7M7n8KjTkIsm3l/2lgVRc2/Gx/v+ZX8lT4FMA+i8aQvhcWylldc+ZNw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.18"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "^2"
+			}
+		},
+		"node_modules/tinybench": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+			"integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/tinyexec": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+			"integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/tinyglobby": {
+			"version": "0.2.15",
+			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+			"integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fdir": "^6.5.0",
+				"picomatch": "^4.0.3"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/SuperchupuDev"
+			}
+		},
+		"node_modules/tinypool": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+			"integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.0.0 || >=20.0.0"
+			}
+		},
+		"node_modules/tinyrainbow": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+			"integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/tinyspy": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+			"integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/tree-dump": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/tree-dump/-/tree-dump-1.1.0.tgz",
+			"integrity": "sha512-rMuvhU4MCDbcbnleZTFezWsaZXRFemSqAM+7jPnzUl1fo9w3YEKOxAeui0fz3OI4EU4hf23iyA7uQRVko+UaBA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true,
+			"license": "0BSD"
 		},
 		"node_modules/tsx": {
 			"version": "4.20.3",
@@ -809,6 +2556,308 @@
 			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/vite": {
+			"version": "7.1.10",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-7.1.10.tgz",
+			"integrity": "sha512-CmuvUBzVJ/e3HGxhg6cYk88NGgTnBoOo7ogtfJJ0fefUWAxN/WDSUa50o+oVBxuIhO8FoEZW0j2eW7sfjs5EtA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"esbuild": "^0.25.0",
+				"fdir": "^6.5.0",
+				"picomatch": "^4.0.3",
+				"postcss": "^8.5.6",
+				"rollup": "^4.43.0",
+				"tinyglobby": "^0.2.15"
+			},
+			"bin": {
+				"vite": "bin/vite.js"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"funding": {
+				"url": "https://github.com/vitejs/vite?sponsor=1"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.3"
+			},
+			"peerDependencies": {
+				"@types/node": "^20.19.0 || >=22.12.0",
+				"jiti": ">=1.21.0",
+				"less": "^4.0.0",
+				"lightningcss": "^1.21.0",
+				"sass": "^1.70.0",
+				"sass-embedded": "^1.70.0",
+				"stylus": ">=0.54.8",
+				"sugarss": "^5.0.0",
+				"terser": "^5.16.0",
+				"tsx": "^4.8.1",
+				"yaml": "^2.4.2"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				},
+				"jiti": {
+					"optional": true
+				},
+				"less": {
+					"optional": true
+				},
+				"lightningcss": {
+					"optional": true
+				},
+				"sass": {
+					"optional": true
+				},
+				"sass-embedded": {
+					"optional": true
+				},
+				"stylus": {
+					"optional": true
+				},
+				"sugarss": {
+					"optional": true
+				},
+				"terser": {
+					"optional": true
+				},
+				"tsx": {
+					"optional": true
+				},
+				"yaml": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/vite-node": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+			"integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cac": "^6.7.14",
+				"debug": "^4.4.1",
+				"es-module-lexer": "^1.7.0",
+				"pathe": "^2.0.3",
+				"vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+			},
+			"bin": {
+				"vite-node": "vite-node.mjs"
+			},
+			"engines": {
+				"node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/vitest": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+			"integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/chai": "^5.2.2",
+				"@vitest/expect": "3.2.4",
+				"@vitest/mocker": "3.2.4",
+				"@vitest/pretty-format": "^3.2.4",
+				"@vitest/runner": "3.2.4",
+				"@vitest/snapshot": "3.2.4",
+				"@vitest/spy": "3.2.4",
+				"@vitest/utils": "3.2.4",
+				"chai": "^5.2.0",
+				"debug": "^4.4.1",
+				"expect-type": "^1.2.1",
+				"magic-string": "^0.30.17",
+				"pathe": "^2.0.3",
+				"picomatch": "^4.0.2",
+				"std-env": "^3.9.0",
+				"tinybench": "^2.9.0",
+				"tinyexec": "^0.3.2",
+				"tinyglobby": "^0.2.14",
+				"tinypool": "^1.1.1",
+				"tinyrainbow": "^2.0.0",
+				"vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+				"vite-node": "3.2.4",
+				"why-is-node-running": "^2.3.0"
+			},
+			"bin": {
+				"vitest": "vitest.mjs"
+			},
+			"engines": {
+				"node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"@edge-runtime/vm": "*",
+				"@types/debug": "^4.1.12",
+				"@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+				"@vitest/browser": "3.2.4",
+				"@vitest/ui": "3.2.4",
+				"happy-dom": "*",
+				"jsdom": "*"
+			},
+			"peerDependenciesMeta": {
+				"@edge-runtime/vm": {
+					"optional": true
+				},
+				"@types/debug": {
+					"optional": true
+				},
+				"@types/node": {
+					"optional": true
+				},
+				"@vitest/browser": {
+					"optional": true
+				},
+				"@vitest/ui": {
+					"optional": true
+				},
+				"happy-dom": {
+					"optional": true
+				},
+				"jsdom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/which": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"node-which": "bin/node-which"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/why-is-node-running": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+			"integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"siginfo": "^2.0.0",
+				"stackback": "0.0.2"
+			},
+			"bin": {
+				"why-is-node-running": "cli.js"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/wrap-ansi": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+			"integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^6.1.0",
+				"string-width": "^5.0.1",
+				"strip-ansi": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi-cjs": {
+			"name": "wrap-ansi",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/wrap-ansi-cjs/node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -37,12 +37,14 @@
 	"devDependencies": {
 		"@biomejs/biome": "^2.1.4",
 		"@types/node": "^22.10.5",
+		"@types/shell-quote": "^1.7.5",
 		"husky": "^9.1.7",
 		"tsx": "^4.20.3",
 		"typescript": "^5.9.2"
 	},
 	"types": "./dist/index.d.ts",
 	"dependencies": {
-		"chalk": "^5.5.0"
+		"chalk": "^5.5.0",
+		"shell-quote": "^1.8.3"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,11 @@
 		"clean": "rm -rf dist",
 		"prepublishOnly": "npm run clean && npm run build",
 		"check": "biome check --write . && tsc --noEmit",
-		"prepare": "husky"
+		"prepare": "husky",
+		"test": "vitest",
+		"test:ui": "vitest --ui",
+		"test:coverage": "vitest --coverage",
+		"test:watch": "vitest --watch"
 	},
 	"files": [
 		"dist/**/*",
@@ -38,9 +42,12 @@
 		"@biomejs/biome": "^2.1.4",
 		"@types/node": "^22.10.5",
 		"@types/shell-quote": "^1.7.5",
+		"@vitest/coverage-v8": "^3.2.4",
 		"husky": "^9.1.7",
+		"memfs": "^4.49.0",
 		"tsx": "^4.20.3",
-		"typescript": "^5.9.2"
+		"typescript": "^5.9.2",
+		"vitest": "^3.2.4"
 	},
 	"types": "./dist/index.d.ts",
 	"dependencies": {

--- a/src/core/cli-patcher.test.ts
+++ b/src/core/cli-patcher.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+import { patchCliVersionCheck } from "./cli-patcher.js";
+
+describe("cli-patcher", () => {
+	describe("patchCliVersionCheck", () => {
+		it("patches version check successfully", () => {
+			const cliContent = `
+function checkVersion() {
+  console.log("It looks like your version of Claude Code is outdated");
+  process.exit(1);
+}
+      `;
+
+			const result = patchCliVersionCheck(cliContent);
+
+			expect(result.patched).toBe(true);
+			expect(result.content).toContain("/* Version check disabled by patch */");
+			expect(result.content).not.toContain("process.exit(1)");
+			expect(result.message).toBe("Version check successfully patched");
+		});
+
+		it("returns unpatched when warning text not found", () => {
+			const cliContent = `
+function someOtherFunction() {
+  console.log("Some other message");
+}
+      `;
+
+			const result = patchCliVersionCheck(cliContent);
+
+			expect(result.patched).toBe(false);
+			expect(result.content).toBe(cliContent);
+			expect(result.message).toBe("Warning text not found - version check may not exist");
+		});
+
+		it("handles complex function bodies", () => {
+			const cliContent = `
+function checkVersion() {
+  const outdated = true;
+  if (outdated) {
+    console.log("It looks like your version of Claude Code is old");
+    console.error("Please update");
+    for (let i = 0; i < 10; i++) {
+      console.log("Warning " + i);
+    }
+  }
+}
+      `;
+
+			const result = patchCliVersionCheck(cliContent);
+
+			expect(result.patched).toBe(true);
+			expect(result.content).toContain("/* Version check disabled by patch */");
+		});
+
+		it("handles nested braces correctly", () => {
+			const cliContent = `
+function checkVersion() {
+  if (true) {
+    if (false) {
+      console.log("It looks like your version of Claude Code is outdated");
+    }
+  }
+}
+      `;
+
+			const result = patchCliVersionCheck(cliContent);
+
+			expect(result.patched).toBe(true);
+			expect(result.content).toContain("function checkVersion()");
+			expect(result.content).toContain("/* Version check disabled by patch */");
+		});
+
+		it("throws error when function keyword not found before warning", () => {
+			const cliContent = `
+const checkVersion = () => {
+  console.log("It looks like your version of Claude Code is outdated");
+};
+      `;
+
+			expect(() => patchCliVersionCheck(cliContent)).toThrow(
+				"Could not find function declaration before warning text",
+			);
+		});
+
+		it("throws error when opening brace not found", () => {
+			const cliContent = `
+function checkVersion()
+  console.log("It looks like your version of Claude Code is outdated");
+      `;
+
+			expect(() => patchCliVersionCheck(cliContent)).toThrow(
+				"Could not find opening brace after function declaration",
+			);
+		});
+
+		it("preserves content before and after patched function", () => {
+			const cliContent = `
+const before = "something before";
+
+function checkVersion() {
+  console.log("It looks like your version of Claude Code is outdated");
+}
+
+const after = "something after";
+      `;
+
+			const result = patchCliVersionCheck(cliContent);
+
+			expect(result.patched).toBe(true);
+			expect(result.content).toContain('const before = "something before"');
+			expect(result.content).toContain('const after = "something after"');
+			expect(result.content).toContain("/* Version check disabled by patch */");
+		});
+
+		it("handles warning text at various positions in function", () => {
+			const cliContent = `
+function checkVersion() {
+  const a = 1;
+  const b = 2;
+  console.log("It looks like your version of Claude Code is old");
+  return false;
+}
+      `;
+
+			const result = patchCliVersionCheck(cliContent);
+
+			expect(result.patched).toBe(true);
+			expect(result.content).toContain("/* Version check disabled by patch */");
+		});
+
+		it("throws error when closing brace not found (unmatched braces)", () => {
+			const cliContent = `
+function checkVersion() {
+  if (true) {
+    console.log("It looks like your version of Claude Code is outdated");
+    // Missing closing brace for if statement
+`;
+
+			expect(() => patchCliVersionCheck(cliContent)).toThrow("Could not find matching closing brace");
+		});
+	});
+});

--- a/src/core/cli-patcher.ts
+++ b/src/core/cli-patcher.ts
@@ -1,0 +1,91 @@
+/**
+ * Pure string manipulation for patching Claude CLI version checks
+ *
+ * FRAGILE: This patching relies on specific string patterns in cli.js
+ * If Claude Code changes the version warning format or uses minification,
+ * this may fail (acceptable - we'll see the warning in that case)
+ */
+
+export interface PatchResult {
+	patched: boolean;
+	content: string;
+	message?: string;
+}
+
+/**
+ * Find the function containing the version warning and patch it
+ * @param cliContent - Content of the CLI file
+ * @returns Patch result with patched content
+ */
+export function patchCliVersionCheck(cliContent: string): PatchResult {
+	const warningText = "It looks like your version of Claude Code";
+	const warningIndex = cliContent.indexOf(warningText);
+
+	if (warningIndex === -1) {
+		return {
+			patched: false,
+			content: cliContent,
+			message: "Warning text not found - version check may not exist",
+		};
+	}
+
+	// Scan backwards from the warning to find "function"
+	let functionIndex = -1;
+	for (let i = warningIndex; i >= 0; i--) {
+		if (cliContent.substring(i, i + 8) === "function") {
+			functionIndex = i;
+			break;
+		}
+	}
+
+	if (functionIndex === -1) {
+		throw new Error("Could not find function declaration before warning text");
+	}
+
+	// Find the opening brace
+	let openBraceIndex = -1;
+	for (let i = functionIndex; i < cliContent.length; i++) {
+		if (cliContent[i] === "{") {
+			openBraceIndex = i;
+			break;
+		}
+	}
+
+	if (openBraceIndex === -1) {
+		throw new Error("Could not find opening brace after function declaration");
+	}
+
+	// Find the matching closing brace
+	let braceCount = 1;
+	let closeBraceIndex = -1;
+
+	for (let i = openBraceIndex + 1; i < cliContent.length; i++) {
+		if (cliContent[i] === "{") {
+			braceCount++;
+		} else if (cliContent[i] === "}") {
+			braceCount--;
+			if (braceCount === 0) {
+				closeBraceIndex = i;
+				break;
+			}
+		}
+	}
+
+	if (closeBraceIndex === -1) {
+		throw new Error("Could not find matching closing brace");
+	}
+
+	// Extract the function declaration
+	const functionDeclaration = cliContent.substring(functionIndex, openBraceIndex + 1);
+
+	// Replace the function body with an empty block
+	const patchedFunction = `${functionDeclaration} /* Version check disabled by patch */ }`;
+	const patchedContent =
+		cliContent.substring(0, functionIndex) + patchedFunction + cliContent.substring(closeBraceIndex + 1);
+
+	return {
+		patched: true,
+		content: patchedContent,
+		message: "Version check successfully patched",
+	};
+}

--- a/src/core/content-extractor.test.ts
+++ b/src/core/content-extractor.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vitest";
+import type { Message, RequestBody } from "../types/request.js";
+import { extractSystemPrompt, extractUserMessage, findAndExtractUserMessage } from "./content-extractor.js";
+
+describe("content-extractor", () => {
+	describe("extractUserMessage", () => {
+		it("extracts text from string content", () => {
+			const message: Message = {
+				role: "user",
+				content: "Hello world",
+			};
+			expect(extractUserMessage(message)).toBe("Hello world");
+		});
+
+		it("extracts text from array content with single text block", () => {
+			const message: Message = {
+				role: "user",
+				content: [{ type: "text", text: "Hello world" }],
+			};
+			expect(extractUserMessage(message)).toBe("Hello world");
+		});
+
+		it("extracts text from array content with multiple text blocks", () => {
+			const message: Message = {
+				role: "user",
+				content: [
+					{ type: "text", text: "Hello" },
+					{ type: "text", text: "World" },
+				],
+			};
+			expect(extractUserMessage(message)).toBe("Hello\nWorld");
+		});
+
+		it("filters out non-text content types", () => {
+			const message: Message = {
+				role: "user",
+				content: [{ type: "text", text: "Hello" }, { type: "image" }, { type: "text", text: "World" }],
+			};
+			expect(extractUserMessage(message)).toBe("Hello\nWorld");
+		});
+
+		it("returns empty string for undefined message", () => {
+			expect(extractUserMessage(undefined)).toBe("");
+		});
+
+		it("returns empty string for empty array content", () => {
+			const message: Message = {
+				role: "user",
+				content: [],
+			};
+			expect(extractUserMessage(message)).toBe("");
+		});
+
+		it("handles text blocks without text property", () => {
+			const message: Message = {
+				role: "user",
+				content: [{ type: "text" }],
+			};
+			expect(extractUserMessage(message)).toBe("");
+		});
+
+		it("returns empty string for invalid content type", () => {
+			const message: any = {
+				role: "user",
+				content: 123, // number instead of string/array
+			};
+			expect(extractUserMessage(message)).toBe("");
+		});
+	});
+
+	describe("extractSystemPrompt", () => {
+		it("extracts single system prompt", () => {
+			const body: RequestBody = {
+				model: "claude",
+				messages: [],
+				system: [{ type: "text", text: "You are Claude" }],
+			};
+			expect(extractSystemPrompt(body)).toBe("You are Claude");
+		});
+
+		it("joins multiple system blocks", () => {
+			const body: RequestBody = {
+				model: "claude",
+				messages: [],
+				system: [
+					{ type: "text", text: "You are Claude" },
+					{ type: "text", text: "Be helpful" },
+				],
+			};
+			expect(extractSystemPrompt(body)).toBe("You are Claude\nBe helpful");
+		});
+
+		it("filters out non-text system blocks", () => {
+			const body: RequestBody = {
+				model: "claude",
+				messages: [],
+				system: [
+					{ type: "text", text: "You are Claude" },
+					{ type: "other", text: "Ignored" },
+					{ type: "text", text: "Be helpful" },
+				],
+			};
+			expect(extractSystemPrompt(body)).toBe("You are Claude\nBe helpful");
+		});
+
+		it("returns empty string when system is undefined", () => {
+			const body: RequestBody = {
+				model: "claude",
+				messages: [],
+			};
+			expect(extractSystemPrompt(body)).toBe("");
+		});
+
+		it("returns empty string when system is empty array", () => {
+			const body: RequestBody = {
+				model: "claude",
+				messages: [],
+				system: [],
+			};
+			expect(extractSystemPrompt(body)).toBe("");
+		});
+	});
+
+	describe("findAndExtractUserMessage", () => {
+		it("finds and extracts first user message", () => {
+			const messages: Message[] = [
+				{ role: "system", content: "System message" },
+				{ role: "user", content: "User message" },
+				{ role: "assistant", content: "Assistant message" },
+			];
+			expect(findAndExtractUserMessage(messages)).toBe("User message");
+		});
+
+		it("returns empty string when no user message found", () => {
+			const messages: Message[] = [
+				{ role: "system", content: "System message" },
+				{ role: "assistant", content: "Assistant message" },
+			];
+			expect(findAndExtractUserMessage(messages)).toBe("");
+		});
+
+		it("handles array content in user message", () => {
+			const messages: Message[] = [
+				{
+					role: "user",
+					content: [
+						{ type: "text", text: "Hello" },
+						{ type: "text", text: "World" },
+					],
+				},
+			];
+			expect(findAndExtractUserMessage(messages)).toBe("Hello\nWorld");
+		});
+
+		it("returns first user message when multiple exist", () => {
+			const messages: Message[] = [
+				{ role: "user", content: "First user" },
+				{ role: "assistant", content: "Response" },
+				{ role: "user", content: "Second user" },
+			];
+			expect(findAndExtractUserMessage(messages)).toBe("First user");
+		});
+	});
+});

--- a/src/core/content-extractor.ts
+++ b/src/core/content-extractor.ts
@@ -1,0 +1,54 @@
+/**
+ * Pure functions for extracting content from Claude API messages
+ */
+
+import type { Message, RequestBody } from "../types/request.js";
+
+/**
+ * Extract user message text from a message object
+ * Handles both string and array content formats
+ * @param message - Message object from Claude API
+ * @returns Extracted text content
+ */
+export function extractUserMessage(message: Message | undefined): string {
+	if (!message) return "";
+
+	const content = message.content;
+
+	// Handle string format
+	if (typeof content === "string") {
+		return content;
+	}
+
+	// Handle array format
+	if (Array.isArray(content)) {
+		return content
+			.filter((item) => item.type === "text")
+			.map((item) => item.text || "")
+			.join("\n");
+	}
+
+	return "";
+}
+
+/**
+ * Extract system prompt from request body
+ * @param body - Request body containing system blocks
+ * @returns Combined system prompt text
+ */
+export function extractSystemPrompt(body: RequestBody): string {
+	return (body.system || [])
+		.filter((s) => s.type === "text")
+		.map((s) => s.text)
+		.join("\n");
+}
+
+/**
+ * Find and extract the first user message from a list of messages
+ * @param messages - Array of message objects
+ * @returns Extracted user message text
+ */
+export function findAndExtractUserMessage(messages: Message[]): string {
+	const userMessage = messages.find((msg) => msg.role === "user");
+	return extractUserMessage(userMessage);
+}

--- a/src/core/jsonl-parser.test.ts
+++ b/src/core/jsonl-parser.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { parseJsonl } from "./jsonl-parser.js";
+
+describe("jsonl-parser", () => {
+	describe("parseJsonl", () => {
+		it("parses single line JSONL", () => {
+			const jsonl = '{"request":{"body":{"model":"claude"}},"response":{}}';
+			const result = parseJsonl(jsonl);
+
+			expect(result).toHaveLength(1);
+			expect(result[0].request.body.model).toBe("claude");
+		});
+
+		it("parses multiple lines JSONL", () => {
+			const jsonl = `{"request":{"body":{"model":"claude-1"}},"response":{}}
+{"request":{"body":{"model":"claude-2"}},"response":{}}
+{"request":{"body":{"model":"claude-3"}},"response":{}}`;
+			const result = parseJsonl(jsonl);
+
+			expect(result).toHaveLength(3);
+			expect(result[0].request.body.model).toBe("claude-1");
+			expect(result[1].request.body.model).toBe("claude-2");
+			expect(result[2].request.body.model).toBe("claude-3");
+		});
+
+		it("filters out empty lines", () => {
+			const jsonl = `{"request":{"body":{"model":"claude-1"}},"response":{}}
+
+{"request":{"body":{"model":"claude-2"}},"response":{}}
+
+`;
+			const result = parseJsonl(jsonl);
+
+			expect(result).toHaveLength(2);
+			expect(result[0].request.body.model).toBe("claude-1");
+			expect(result[1].request.body.model).toBe("claude-2");
+		});
+
+		it("handles trailing newline", () => {
+			const jsonl = '{"request":{"body":{"model":"claude"}},"response":{}}\n';
+			const result = parseJsonl(jsonl);
+
+			expect(result).toHaveLength(1);
+			expect(result[0].request.body.model).toBe("claude");
+		});
+
+		it("handles leading/trailing whitespace", () => {
+			const jsonl = '  {"request":{"body":{"model":"claude"}},"response":{}}  \n';
+			const result = parseJsonl(jsonl);
+
+			expect(result).toHaveLength(1);
+			expect(result[0].request.body.model).toBe("claude");
+		});
+
+		it("parses complex nested objects", () => {
+			const jsonl = `{"request":{"timestamp":123,"body":{"model":"claude","messages":[{"role":"user","content":"test"}],"tools":[{"name":"tool1","description":"desc"}]}},"response":{"status":"ok"}}`;
+			const result = parseJsonl(jsonl);
+
+			expect(result).toHaveLength(1);
+			expect(result[0].request.timestamp).toBe(123);
+			expect(result[0].request.body.messages).toHaveLength(1);
+			expect(result[0].request.body.messages[0].role).toBe("user");
+			expect(result[0].request.body.tools).toHaveLength(1);
+			expect(result[0].response.status).toBe("ok");
+		});
+	});
+});

--- a/src/core/jsonl-parser.ts
+++ b/src/core/jsonl-parser.ts
@@ -1,0 +1,18 @@
+/**
+ * Pure parser for JSONL (JSON Lines) format
+ */
+
+import type { RequestResponsePair } from "../types/request.js";
+
+/**
+ * Parse JSONL content into structured request/response pairs
+ * @param content - JSONL string where each line is a separate JSON object
+ * @returns Array of parsed request/response pairs
+ */
+export function parseJsonl(content: string): RequestResponsePair[] {
+	return content
+		.trim()
+		.split("\n")
+		.filter((line) => line.trim())
+		.map((line) => JSON.parse(line) as RequestResponsePair);
+}

--- a/src/core/output-formatter.test.ts
+++ b/src/core/output-formatter.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, it } from "vitest";
+import type { Tool } from "../types/request.js";
+import { formatOutput, formatTools, indentHeaders } from "./output-formatter.js";
+
+describe("output-formatter", () => {
+	describe("indentHeaders", () => {
+		it("adds # to single-level header", () => {
+			expect(indentHeaders("# Header")).toBe("## Header");
+		});
+
+		it("adds # to multi-level headers", () => {
+			const input = "# H1\n## H2\n### H3";
+			const expected = "## H1\n### H2\n#### H3";
+			expect(indentHeaders(input)).toBe(expected);
+		});
+
+		it("preserves non-header lines", () => {
+			const input = "# Header\nRegular text\n## Subheader";
+			const expected = "## Header\nRegular text\n### Subheader";
+			expect(indentHeaders(input)).toBe(expected);
+		});
+
+		it("requires space after #", () => {
+			expect(indentHeaders("#NoSpace")).toBe("#NoSpace");
+			expect(indentHeaders("# Space")).toBe("## Space");
+		});
+
+		it("handles empty string", () => {
+			expect(indentHeaders("")).toBe("");
+		});
+
+		it("handles headers with extra spaces", () => {
+			expect(indentHeaders("##  Header")).toBe("###  Header");
+		});
+	});
+
+	describe("formatTools", () => {
+		it("formats single tool", () => {
+			const tools: Tool[] = [
+				{
+					name: "test_tool",
+					description: "A test tool",
+					input_schema: { type: "object", properties: {} },
+				},
+			];
+
+			const result = formatTools(tools);
+			expect(result).toContain("## test_tool");
+			expect(result).toContain("A test tool");
+			expect(result).toContain('"type": "object"');
+		});
+
+		it("formats multiple tools with separator", () => {
+			const tools: Tool[] = [
+				{
+					name: "tool1",
+					description: "First",
+					input_schema: { type: "object" },
+				},
+				{
+					name: "tool2",
+					description: "Second",
+					input_schema: { type: "object" },
+				},
+			];
+
+			const result = formatTools(tools);
+			expect(result).toContain("## tool1");
+			expect(result).toContain("## tool2");
+			expect(result).toContain("\n\n---\n\n");
+		});
+
+		it("indents headers in tool descriptions twice", () => {
+			const tools: Tool[] = [
+				{
+					name: "test_tool",
+					description: "# Description\n## Details",
+					input_schema: { type: "object" },
+				},
+			];
+
+			const result = formatTools(tools);
+			// Headers should be indented twice: # -> ## -> ###, ## -> ### -> ####
+			expect(result).toContain("### Description");
+			expect(result).toContain("#### Details");
+		});
+
+		it("formats empty tools array", () => {
+			const result = formatTools([]);
+			expect(result).toBe("");
+		});
+
+		it("formats schema with proper indentation", () => {
+			const tools: Tool[] = [
+				{
+					name: "test_tool",
+					description: "Test",
+					input_schema: {
+						type: "object",
+						properties: {
+							field: { type: "string" },
+						},
+					},
+				},
+			];
+
+			const result = formatTools(tools);
+			expect(result).toContain('  "type": "object"');
+			expect(result).toContain('  "properties"');
+		});
+	});
+
+	describe("formatOutput", () => {
+		it("formats complete output document", () => {
+			const data = {
+				versionLabel: "1.0.0",
+				releaseDate: "2024-01-01",
+				userMessage: "Test message",
+				systemPrompt: "You are Claude",
+				tools: [
+					{
+						name: "tool1",
+						description: "A tool",
+						input_schema: { type: "object" },
+					},
+				],
+			};
+
+			const result = formatOutput(data);
+
+			expect(result).toContain("# Claude Code Version 1.0.0");
+			expect(result).toContain("Release Date: 2024-01-01");
+			expect(result).toContain("# User Message");
+			expect(result).toContain("Test message");
+			expect(result).toContain("# System Prompt");
+			expect(result).toContain("You are Claude");
+			expect(result).toContain("# Tools");
+			expect(result).toContain("## tool1");
+		});
+
+		it("indents user message headers", () => {
+			const data = {
+				versionLabel: "1.0.0",
+				releaseDate: "2024-01-01",
+				userMessage: "# User Header\nContent",
+				systemPrompt: "System",
+				tools: [],
+			};
+
+			const result = formatOutput(data);
+			expect(result).toContain("## User Header");
+		});
+
+		it("indents system prompt headers", () => {
+			const data = {
+				versionLabel: "1.0.0",
+				releaseDate: "2024-01-01",
+				userMessage: "User",
+				systemPrompt: "# System Header\nContent",
+				tools: [],
+			};
+
+			const result = formatOutput(data);
+			expect(result).toContain("## System Header");
+		});
+
+		it("handles empty tools array", () => {
+			const data = {
+				versionLabel: "1.0.0",
+				releaseDate: "2024-01-01",
+				userMessage: "Test",
+				systemPrompt: "System",
+				tools: [],
+			};
+
+			const result = formatOutput(data);
+			expect(result).toContain("# Tools");
+			// Should have tools section but empty content
+			expect(result.split("# Tools")[1].trim()).toBe("");
+		});
+
+		it("formats custom binary label", () => {
+			const data = {
+				versionLabel: "Custom Binary (prompts-custom-2024.md)",
+				releaseDate: "Custom Binary",
+				userMessage: "Test",
+				systemPrompt: "System",
+				tools: [],
+			};
+
+			const result = formatOutput(data);
+			expect(result).toContain("# Claude Code Version Custom Binary (prompts-custom-2024.md)");
+			expect(result).toContain("Release Date: Custom Binary");
+		});
+
+		it("includes proper spacing between sections", () => {
+			const data = {
+				versionLabel: "1.0.0",
+				releaseDate: "2024-01-01",
+				userMessage: "User",
+				systemPrompt: "System",
+				tools: [],
+			};
+
+			const result = formatOutput(data);
+
+			// Check for blank lines between sections
+			expect(result).toContain("Release Date: 2024-01-01\n\n# User Message");
+			expect(result).toContain("User\n\n# System Prompt");
+			expect(result).toContain("System\n\n# Tools");
+		});
+	});
+});

--- a/src/core/output-formatter.ts
+++ b/src/core/output-formatter.ts
@@ -1,0 +1,74 @@
+/**
+ * Pure functions for formatting output markdown
+ */
+
+import type { Tool } from "../types/request.js";
+
+export interface OutputData {
+	versionLabel: string;
+	releaseDate: string;
+	userMessage: string;
+	systemPrompt: string;
+	tools: Tool[];
+}
+
+/**
+ * Add an extra # to all markdown headers in text
+ * This indents headers by one level (e.g., # becomes ##)
+ * @param text - Text containing markdown headers
+ * @returns Text with indented headers
+ */
+export function indentHeaders(text: string): string {
+	return text
+		.split("\n")
+		.map((line) => {
+			const match = line.match(/^(#+)(\s+)/);
+			if (match) {
+				return `#${line}`;
+			}
+			return line;
+		})
+		.join("\n");
+}
+
+/**
+ * Format tools as markdown sections
+ * @param tools - Array of tools to format
+ * @returns Formatted markdown string
+ */
+export function formatTools(tools: Tool[]): string {
+	return tools
+		.map((tool) => {
+			const schemaStr = JSON.stringify(tool.input_schema, null, 2);
+			// Apply indentation twice to make headers in tool descriptions smaller
+			const indentedDescription = indentHeaders(indentHeaders(tool.description));
+			return `## ${tool.name}\n\n${indentedDescription}\n${schemaStr}`;
+		})
+		.join("\n\n---\n\n");
+}
+
+/**
+ * Format complete output document
+ * @param data - Output data structure
+ * @returns Complete formatted markdown document
+ */
+export function formatOutput(data: OutputData): string {
+	const toolsSection = formatTools(data.tools);
+
+	return `# Claude Code Version ${data.versionLabel}
+
+Release Date: ${data.releaseDate}
+
+# User Message
+
+${indentHeaders(data.userMessage)}
+
+# System Prompt
+
+${indentHeaders(data.systemPrompt)}
+
+# Tools
+
+${toolsSection}
+`;
+}

--- a/src/core/request-filter.test.ts
+++ b/src/core/request-filter.test.ts
@@ -1,0 +1,495 @@
+import { describe, expect, it } from "vitest";
+import type { RequestResponsePair, Tool } from "../types/request.js";
+import {
+	filterAndSortTools,
+	filterNonHaikuRequests,
+	filterRequestsWithTools,
+	hasTools,
+	selectBestRequest,
+} from "./request-filter.js";
+
+describe("request-filter", () => {
+	describe("filterNonHaikuRequests", () => {
+		it("filters out haiku models", () => {
+			const pairs: RequestResponsePair[] = [
+				{
+					request: {
+						timestamp: 1,
+						method: "POST",
+						url: "/",
+						headers: {},
+						body: { model: "claude-3-haiku-20240307", messages: [] },
+					},
+					response: {},
+				},
+				{
+					request: {
+						timestamp: 2,
+						method: "POST",
+						url: "/",
+						headers: {},
+						body: { model: "claude-3-5-sonnet-20241022", messages: [] },
+					},
+					response: {},
+				},
+			];
+
+			const result = filterNonHaikuRequests(pairs);
+			expect(result).toHaveLength(1);
+			expect(result[0].request.body.model).toBe("claude-3-5-sonnet-20241022");
+		});
+
+		it("handles case-insensitive haiku detection", () => {
+			const pairs: RequestResponsePair[] = [
+				{
+					request: {
+						timestamp: 1,
+						method: "POST",
+						url: "/",
+						headers: {},
+						body: { model: "claude-HAIKU-test", messages: [] },
+					},
+					response: {},
+				},
+				{
+					request: {
+						timestamp: 2,
+						method: "POST",
+						url: "/",
+						headers: {},
+						body: { model: "claude-sonnet", messages: [] },
+					},
+					response: {},
+				},
+			];
+
+			const result = filterNonHaikuRequests(pairs);
+			expect(result).toHaveLength(1);
+			expect(result[0].request.body.model).toBe("claude-sonnet");
+		});
+
+		it("returns all non-haiku models", () => {
+			const pairs: RequestResponsePair[] = [
+				{
+					request: {
+						timestamp: 1,
+						method: "POST",
+						url: "/",
+						headers: {},
+						body: { model: "claude-sonnet-1", messages: [] },
+					},
+					response: {},
+				},
+				{
+					request: {
+						timestamp: 2,
+						method: "POST",
+						url: "/",
+						headers: {},
+						body: { model: "claude-sonnet-2", messages: [] },
+					},
+					response: {},
+				},
+			];
+
+			const result = filterNonHaikuRequests(pairs);
+			expect(result).toHaveLength(2);
+		});
+	});
+
+	describe("filterRequestsWithTools", () => {
+		it("filters requests with tools", () => {
+			const pairs: RequestResponsePair[] = [
+				{
+					request: {
+						timestamp: 1,
+						method: "POST",
+						url: "/",
+						headers: {},
+						body: { model: "claude", messages: [], tools: [] },
+					},
+					response: {},
+				},
+				{
+					request: {
+						timestamp: 2,
+						method: "POST",
+						url: "/",
+						headers: {},
+						body: {
+							model: "claude",
+							messages: [],
+							tools: [
+								{
+									name: "tool1",
+									description: "desc",
+									input_schema: { type: "object" },
+								},
+							],
+						},
+					},
+					response: {},
+				},
+			];
+
+			const result = filterRequestsWithTools(pairs);
+			expect(result).toHaveLength(1);
+			expect(result[0].request.body.tools).toHaveLength(1);
+		});
+
+		it("excludes requests with empty tools array", () => {
+			const pairs: RequestResponsePair[] = [
+				{
+					request: {
+						timestamp: 1,
+						method: "POST",
+						url: "/",
+						headers: {},
+						body: { model: "claude", messages: [], tools: [] },
+					},
+					response: {},
+				},
+			];
+
+			const result = filterRequestsWithTools(pairs);
+			expect(result).toHaveLength(0);
+		});
+
+		it("excludes requests without tools property", () => {
+			const pairs: RequestResponsePair[] = [
+				{
+					request: {
+						timestamp: 1,
+						method: "POST",
+						url: "/",
+						headers: {},
+						body: { model: "claude", messages: [] },
+					},
+					response: {},
+				},
+			];
+
+			const result = filterRequestsWithTools(pairs);
+			expect(result).toHaveLength(0);
+		});
+	});
+
+	describe("selectBestRequest", () => {
+		it("selects request with most tools", () => {
+			const pairs: RequestResponsePair[] = [
+				{
+					request: {
+						timestamp: 1,
+						method: "POST",
+						url: "/",
+						headers: {},
+						body: {
+							model: "claude-sonnet",
+							messages: [],
+							tools: [
+								{
+									name: "tool1",
+									description: "desc",
+									input_schema: { type: "object" },
+								},
+							],
+						},
+					},
+					response: {},
+				},
+				{
+					request: {
+						timestamp: 2,
+						method: "POST",
+						url: "/",
+						headers: {},
+						body: {
+							model: "claude-sonnet",
+							messages: [],
+							tools: [
+								{
+									name: "tool1",
+									description: "desc",
+									input_schema: { type: "object" },
+								},
+								{
+									name: "tool2",
+									description: "desc",
+									input_schema: { type: "object" },
+								},
+							],
+						},
+					},
+					response: {},
+				},
+			];
+
+			const result = selectBestRequest(pairs);
+			expect(result.request.body.tools).toHaveLength(2);
+		});
+
+		it("falls back to non-haiku request when no tools found", () => {
+			const pairs: RequestResponsePair[] = [
+				{
+					request: {
+						timestamp: 1,
+						method: "POST",
+						url: "/",
+						headers: {},
+						body: { model: "claude-haiku", messages: [] },
+					},
+					response: {},
+				},
+				{
+					request: {
+						timestamp: 2,
+						method: "POST",
+						url: "/",
+						headers: {},
+						body: { model: "claude-sonnet", messages: [] },
+					},
+					response: {},
+				},
+			];
+
+			const result = selectBestRequest(pairs);
+			expect(result.request.body.model).toBe("claude-sonnet");
+		});
+
+		it("throws error when no non-haiku request found", () => {
+			const pairs: RequestResponsePair[] = [
+				{
+					request: {
+						timestamp: 1,
+						method: "POST",
+						url: "/",
+						headers: {},
+						body: { model: "claude-haiku", messages: [] },
+					},
+					response: {},
+				},
+			];
+
+			expect(() => selectBestRequest(pairs)).toThrow("No non-Haiku request found in the log");
+		});
+
+		it("filters out haiku before selecting best", () => {
+			const pairs: RequestResponsePair[] = [
+				{
+					request: {
+						timestamp: 1,
+						method: "POST",
+						url: "/",
+						headers: {},
+						body: {
+							model: "claude-haiku",
+							messages: [],
+							tools: [
+								{
+									name: "tool1",
+									description: "desc",
+									input_schema: { type: "object" },
+								},
+								{
+									name: "tool2",
+									description: "desc",
+									input_schema: { type: "object" },
+								},
+								{
+									name: "tool3",
+									description: "desc",
+									input_schema: { type: "object" },
+								},
+							],
+						},
+					},
+					response: {},
+				},
+				{
+					request: {
+						timestamp: 2,
+						method: "POST",
+						url: "/",
+						headers: {},
+						body: {
+							model: "claude-sonnet",
+							messages: [],
+							tools: [
+								{
+									name: "tool1",
+									description: "desc",
+									input_schema: { type: "object" },
+								},
+							],
+						},
+					},
+					response: {},
+				},
+			];
+
+			const result = selectBestRequest(pairs);
+			// Should select sonnet even though haiku has more tools
+			expect(result.request.body.model).toBe("claude-sonnet");
+		});
+
+		it("handles requests with undefined tools in sorting", () => {
+			const pairs: RequestResponsePair[] = [
+				{
+					request: {
+						timestamp: 1,
+						method: "POST",
+						url: "/",
+						headers: {},
+						body: {
+							model: "claude-sonnet",
+							messages: [],
+							tools: [
+								{
+									name: "tool1",
+									description: "desc",
+									input_schema: { type: "object" },
+								},
+							],
+						},
+					},
+					response: {},
+				},
+				{
+					request: {
+						timestamp: 2,
+						method: "POST",
+						url: "/",
+						headers: {},
+						body: {
+							model: "claude-sonnet",
+							messages: [],
+							// tools property exists but is undefined (edge case)
+							tools: undefined,
+						} as any,
+					},
+					response: {},
+				},
+			];
+
+			// Should handle undefined tools gracefully during sort
+			const result = selectBestRequest(pairs);
+			expect(result.request.body.tools).toHaveLength(1);
+		});
+	});
+
+	describe("filterAndSortTools", () => {
+		it("filters out mcp__ tools", () => {
+			const tools: Tool[] = [
+				{
+					name: "mcp__tool1",
+					description: "desc",
+					input_schema: { type: "object" },
+				},
+				{
+					name: "regular_tool",
+					description: "desc",
+					input_schema: { type: "object" },
+				},
+				{
+					name: "mcp__tool2",
+					description: "desc",
+					input_schema: { type: "object" },
+				},
+			];
+
+			const result = filterAndSortTools(tools);
+			expect(result).toHaveLength(1);
+			expect(result[0].name).toBe("regular_tool");
+		});
+
+		it("sorts tools alphabetically by name", () => {
+			const tools: Tool[] = [
+				{
+					name: "zebra",
+					description: "desc",
+					input_schema: { type: "object" },
+				},
+				{
+					name: "alpha",
+					description: "desc",
+					input_schema: { type: "object" },
+				},
+				{
+					name: "beta",
+					description: "desc",
+					input_schema: { type: "object" },
+				},
+			];
+
+			const result = filterAndSortTools(tools);
+			expect(result.map((t) => t.name)).toEqual(["alpha", "beta", "zebra"]);
+		});
+
+		it("returns empty array for undefined tools", () => {
+			const result = filterAndSortTools(undefined);
+			expect(result).toEqual([]);
+		});
+
+		it("returns empty array for empty tools array", () => {
+			const result = filterAndSortTools([]);
+			expect(result).toEqual([]);
+		});
+	});
+
+	describe("hasTools", () => {
+		it("returns true when request has tools", () => {
+			const pair: RequestResponsePair = {
+				request: {
+					timestamp: 1,
+					method: "POST",
+					url: "/",
+					headers: {},
+					body: {
+						model: "claude",
+						messages: [],
+						tools: [
+							{
+								name: "tool1",
+								description: "desc",
+								input_schema: { type: "object" },
+							},
+						],
+					},
+				},
+				response: {},
+			};
+
+			expect(hasTools(pair)).toBe(true);
+		});
+
+		it("returns false when tools array is empty", () => {
+			const pair: RequestResponsePair = {
+				request: {
+					timestamp: 1,
+					method: "POST",
+					url: "/",
+					headers: {},
+					body: { model: "claude", messages: [], tools: [] },
+				},
+				response: {},
+			};
+
+			expect(hasTools(pair)).toBe(false);
+		});
+
+		it("returns false when tools is undefined", () => {
+			const pair: RequestResponsePair = {
+				request: {
+					timestamp: 1,
+					method: "POST",
+					url: "/",
+					headers: {},
+					body: { model: "claude", messages: [] },
+				},
+				response: {},
+			};
+
+			expect(hasTools(pair)).toBe(false);
+		});
+	});
+});

--- a/src/core/request-filter.ts
+++ b/src/core/request-filter.ts
@@ -1,0 +1,75 @@
+/**
+ * Pure functions for filtering and selecting Claude API requests
+ */
+
+import type { RequestResponsePair, Tool } from "../types/request.js";
+
+/**
+ * Filter out Haiku model requests
+ * @param pairs - Array of request/response pairs
+ * @returns Pairs not using Haiku models
+ */
+export function filterNonHaikuRequests(pairs: RequestResponsePair[]): RequestResponsePair[] {
+	return pairs.filter((pair) => pair.request?.body?.model && !pair.request.body.model.toLowerCase().includes("haiku"));
+}
+
+/**
+ * Filter requests that have tools defined
+ * @param pairs - Array of request/response pairs
+ * @returns Pairs with tools
+ */
+export function filterRequestsWithTools(pairs: RequestResponsePair[]): RequestResponsePair[] {
+	return pairs.filter(
+		(pair) =>
+			pair.request?.body?.tools && Array.isArray(pair.request.body.tools) && pair.request.body.tools.length > 0,
+	);
+}
+
+/**
+ * Select the best request from candidates
+ * Prefers non-Haiku requests with tools, sorted by tool count (descending)
+ * Falls back to any non-Haiku request if no tools found
+ * @param pairs - Array of request/response pairs
+ * @returns The best request, or undefined if none found
+ * @throws Error if no suitable request is found
+ */
+export function selectBestRequest(pairs: RequestResponsePair[]): RequestResponsePair {
+	// First try to find requests with tools
+	const nonHaikuPairs = filterNonHaikuRequests(pairs);
+	const requestsWithTools = filterRequestsWithTools(nonHaikuPairs);
+
+	if (requestsWithTools.length > 0) {
+		// Sort by tool count (descending) and return the best
+		const sorted = requestsWithTools.sort(
+			(a, b) => (b.request.body.tools?.length || 0) - (a.request.body.tools?.length || 0),
+		);
+		return sorted[0];
+	}
+
+	// Fallback to any non-Haiku request
+	if (nonHaikuPairs.length > 0) {
+		return nonHaikuPairs[0];
+	}
+
+	throw new Error("No non-Haiku request found in the log");
+}
+
+/**
+ * Filter out MCP tools and sort tools by name
+ * @param tools - Array of tools
+ * @returns Filtered and sorted tools
+ */
+export function filterAndSortTools(tools: Tool[] | undefined): Tool[] {
+	if (!tools) return [];
+
+	return tools.filter((tool) => !tool.name.startsWith("mcp__")).sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * Check if selected request has tools (for warning purposes)
+ * @param pair - Request/response pair
+ * @returns True if request has tools
+ */
+export function hasTools(pair: RequestResponsePair): boolean {
+	return !!pair.request.body.tools && Array.isArray(pair.request.body.tools) && pair.request.body.tools.length > 0;
+}

--- a/src/core/version-utils.test.ts
+++ b/src/core/version-utils.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { compareVersions, parseVersion } from "./version-utils.js";
+
+describe("version-utils", () => {
+	describe("parseVersion", () => {
+		it("parses a simple version string", () => {
+			expect(parseVersion("1.2.3")).toEqual({
+				major: 1,
+				minor: 2,
+				patch: 3,
+			});
+		});
+
+		it("parses version with zeros", () => {
+			expect(parseVersion("0.0.0")).toEqual({
+				major: 0,
+				minor: 0,
+				patch: 0,
+			});
+		});
+
+		it("parses version with large numbers", () => {
+			expect(parseVersion("10.20.30")).toEqual({
+				major: 10,
+				minor: 20,
+				patch: 30,
+			});
+		});
+	});
+
+	describe("compareVersions", () => {
+		it("returns negative when first version is less than second", () => {
+			expect(compareVersions("1.2.3", "1.2.4")).toBeLessThan(0);
+			expect(compareVersions("1.2.3", "1.3.0")).toBeLessThan(0);
+			expect(compareVersions("1.2.3", "2.0.0")).toBeLessThan(0);
+		});
+
+		it("returns positive when first version is greater than second", () => {
+			expect(compareVersions("1.2.4", "1.2.3")).toBeGreaterThan(0);
+			expect(compareVersions("1.3.0", "1.2.3")).toBeGreaterThan(0);
+			expect(compareVersions("2.0.0", "1.2.3")).toBeGreaterThan(0);
+		});
+
+		it("returns zero when versions are equal", () => {
+			expect(compareVersions("1.2.3", "1.2.3")).toBe(0);
+			expect(compareVersions("0.0.0", "0.0.0")).toBe(0);
+			expect(compareVersions("10.20.30", "10.20.30")).toBe(0);
+		});
+
+		it("compares major version first", () => {
+			expect(compareVersions("2.0.0", "1.9.9")).toBeGreaterThan(0);
+			expect(compareVersions("1.0.0", "2.0.0")).toBeLessThan(0);
+		});
+
+		it("compares minor version when major is equal", () => {
+			expect(compareVersions("1.2.0", "1.1.9")).toBeGreaterThan(0);
+			expect(compareVersions("1.1.0", "1.2.0")).toBeLessThan(0);
+		});
+
+		it("compares patch version when major and minor are equal", () => {
+			expect(compareVersions("1.2.3", "1.2.2")).toBeGreaterThan(0);
+			expect(compareVersions("1.2.2", "1.2.3")).toBeLessThan(0);
+		});
+	});
+});

--- a/src/core/version-utils.ts
+++ b/src/core/version-utils.ts
@@ -1,0 +1,38 @@
+/**
+ * Pure utility functions for version parsing and comparison
+ */
+
+export interface Version {
+	major: number;
+	minor: number;
+	patch: number;
+}
+
+/**
+ * Parse a semantic version string into its components
+ * @param version - Version string in format "major.minor.patch"
+ * @returns Parsed version object
+ */
+export function parseVersion(version: string): Version {
+	const parts = version.split(".");
+	return {
+		major: parseInt(parts[0], 10),
+		minor: parseInt(parts[1], 10),
+		patch: parseInt(parts[2], 10),
+	};
+}
+
+/**
+ * Compare two version strings
+ * @param a - First version string
+ * @param b - Second version string
+ * @returns Negative if a < b, positive if a > b, zero if equal
+ */
+export function compareVersions(a: string, b: string): number {
+	const va = parseVersion(a);
+	const vb = parseVersion(b);
+
+	if (va.major !== vb.major) return va.major - vb.major;
+	if (va.minor !== vb.minor) return va.minor - vb.minor;
+	return va.patch - vb.patch;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,10 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import chalk from "chalk";
+import { parse, quote } from "shell-quote";
+
+/** cchistory's own flags - used for argument validation */
+const CCHISTORY_FLAGS = ["--latest", "--binary-path", "--claude-args", "--version", "-v", "--help", "-h"];
 
 interface CacheControl {
 	type: string;
@@ -51,7 +55,11 @@ interface RequestResponsePair {
 	response: Record<string, unknown>;
 }
 
-function parseVersion(version: string): { major: number; minor: number; patch: number } {
+function parseVersion(version: string): {
+	major: number;
+	minor: number;
+	patch: number;
+} {
 	const parts = version.split(".");
 	return {
 		major: parseInt(parts[0], 10),
@@ -79,7 +87,11 @@ function getLatestVersion(): string {
 	} catch (error) {
 		console.error(chalk.red("Failed to fetch latest version from npm:"));
 		console.error(chalk.gray("Command: npm view @anthropic-ai/claude-code version"));
-		const errorObj = error as { stdout?: string; stderr?: string; message?: string };
+		const errorObj = error as {
+			stdout?: string;
+			stderr?: string;
+			message?: string;
+		};
 		if (errorObj.stdout) console.error(chalk.gray("stdout:"), errorObj.stdout);
 		if (errorObj.stderr) console.error(chalk.gray("stderr:"), errorObj.stderr);
 		console.error(chalk.gray("Error:"), error instanceof Error ? error.message : String(error));
@@ -105,7 +117,11 @@ function getAllVersionsBetween(startVersion: string, endVersion: string): string
 	} catch (error) {
 		console.error(chalk.red("Failed to fetch version list from npm:"));
 		console.error(chalk.gray("Command: npm view @anthropic-ai/claude-code versions --json"));
-		const errorObj = error as { stdout?: string; stderr?: string; message?: string };
+		const errorObj = error as {
+			stdout?: string;
+			stderr?: string;
+			message?: string;
+		};
 		if (errorObj.stdout) console.error(chalk.gray("stdout:"), errorObj.stdout);
 		if (errorObj.stderr) console.error(chalk.gray("stderr:"), errorObj.stderr);
 		console.error(chalk.gray("Error:"), error instanceof Error ? error.message : String(error));
@@ -115,7 +131,7 @@ function getAllVersionsBetween(startVersion: string, endVersion: string): string
 
 function getVersionReleaseDate(version: string): string {
 	try {
-		const output = execSync(`npm view @anthropic-ai/claude-code@${version} time --json`, {
+		const output = execSync(`npm view @anthropic-ai/claude-code@${quote([version])} time --json`, {
 			encoding: "utf-8",
 			stdio: ["pipe", "pipe", "pipe"],
 		});
@@ -127,154 +143,209 @@ function getVersionReleaseDate(version: string): string {
 	}
 }
 
-async function processVersion(version: string, originalCwd: string) {
-	// Check if prompts file already exists
-	const outputPath = path.join(originalCwd, `prompts-${version}.md`);
+/**
+ * Creates a temporary working directory with an empty CLAUDE.md file
+ * @param prefix - Prefix for the temp directory name
+ * @returns Path to the created temporary directory
+ */
+function createTempWorkDir(prefix: string): string {
+	const tmpBaseDir = os.tmpdir();
+	const tmpDirName = `${prefix}-${Date.now()}-${Math.random().toString(36).substring(2, 8)}`;
+	const tmpDir = path.join(tmpBaseDir, tmpDirName);
+	fs.mkdirSync(tmpDir, { recursive: true });
+	fs.writeFileSync(path.join(tmpDir, "CLAUDE.md"), "");
+	return tmpDir;
+}
+
+/**
+ * Process a single Claude Code version and extract its prompts, tools, and system messages
+ * @param versionOrLabel - NPM version string (e.g., "1.0.0") or custom label for output filename
+ * @param originalCwd - Original working directory for output files
+ * @param customBinaryPath - Optional path to a custom Claude Code binary
+ * @param claudeArgs - Optional arguments to pass to Claude Code during execution
+ */
+async function processVersion(
+	versionOrLabel: string,
+	originalCwd: string,
+	customBinaryPath?: string,
+	claudeArgs?: string,
+) {
+	const outputFilename = customBinaryPath
+		? `prompts-custom-${new Date().toISOString().replace(/[:.]/g, "-")}.md`
+		: `prompts-${versionOrLabel}.md`;
+	const outputPath = path.join(originalCwd, outputFilename);
+
 	if (fs.existsSync(outputPath)) {
-		console.log(chalk.gray(`Skipping ${version} - already exists`));
+		console.log(chalk.gray(`Skipping ${customBinaryPath ? "custom binary" : versionOrLabel} - already exists`));
 		return;
 	}
 
-	console.log(chalk.blue(`Processing ${version}...`));
-	// Create a unique temp directory
-	const tmpBaseDir = os.tmpdir();
-	const tmpDirName = `claude-history-${Date.now()}-${Math.random().toString(36).substring(2, 8)}`;
-	const tmpDir = path.join(tmpBaseDir, tmpDirName);
-	const packageDir = path.join(tmpDir, "package");
-	const cliPath = path.join(packageDir, "cli.js");
+	console.log(
+		chalk.blue(`Processing ${customBinaryPath ? `custom binary (${customBinaryPath})` : versionOrLabel}...`),
+	);
 
-	// Create tmp directory
-	fs.mkdirSync(tmpDir, { recursive: true });
+	// Determine CLI path and whether to use temp directory
+	let cliPath: string;
+	let tmpDir: string | undefined;
+	let packageDir: string | undefined;
 
-	// Download and extract package
-	try {
-		execSync(`npm pack @anthropic-ai/claude-code@${version}`, {
+	if (customBinaryPath) {
+		cliPath = customBinaryPath;
+	} else {
+		tmpDir = createTempWorkDir("claude-history");
+		packageDir = path.join(tmpDir, "package");
+		cliPath = path.join(packageDir, "cli.js");
+
+		try {
+			execSync(`npm pack @anthropic-ai/claude-code@${quote([versionOrLabel])}`, {
+				cwd: tmpDir,
+				stdio: ["pipe", "pipe", "pipe"],
+			});
+		} catch (error) {
+			console.error(chalk.red(`Failed to download version ${versionOrLabel} from npm:`));
+			console.error(chalk.gray(`Command: npm pack @anthropic-ai/claude-code@${versionOrLabel}`));
+			const errorObj = error as {
+				stdout?: string;
+				stderr?: string;
+				message?: string;
+			};
+			if (errorObj.stdout) console.error(chalk.gray("stdout:"), errorObj.stdout);
+			if (errorObj.stderr) console.error(chalk.gray("stderr:"), errorObj.stderr);
+			console.error(chalk.gray("Error:"), error instanceof Error ? error.message : String(error));
+			throw error;
+		}
+
+		const tarFile = path.join(tmpDir, `anthropic-ai-claude-code-${versionOrLabel}.tgz`);
+		execSync(`tar -xzf ${quote([tarFile])}`, {
 			cwd: tmpDir,
 			stdio: ["pipe", "pipe", "pipe"],
 		});
-	} catch (error) {
-		console.error(chalk.red(`Failed to download version ${version} from npm:`));
-		console.error(chalk.gray(`Command: npm pack @anthropic-ai/claude-code@${version}`));
-		const errorObj = error as { stdout?: string; stderr?: string; message?: string };
-		if (errorObj.stdout) console.error(chalk.gray("stdout:"), errorObj.stdout);
-		if (errorObj.stderr) console.error(chalk.gray("stderr:"), errorObj.stderr);
-		console.error(chalk.gray("Error:"), error instanceof Error ? error.message : String(error));
-		throw error;
-	}
 
-	const tarFile = path.join(tmpDir, `anthropic-ai-claude-code-${version}.tgz`);
-	execSync(`tar -xzf "${tarFile}"`, {
-		cwd: tmpDir,
-		stdio: ["pipe", "pipe", "pipe"],
-	});
-
-	// Patch cli.js silently
-
-	// Check if cli.js exists
-	if (!fs.existsSync(cliPath)) {
-		console.error(chalk.red(`CLI file not found for version ${version}`));
-		console.error(chalk.gray("Expected path:"), cliPath);
-		console.error(chalk.gray("Package contents:"));
-		try {
-			const packageFiles = fs.readdirSync(packageDir);
-			packageFiles.forEach((file) => console.error(chalk.gray(`  - ${file}`)));
-		} catch (_e) {
-			console.error(chalk.gray("  Could not list package directory"));
-		}
-		throw new Error(`CLI file not found at ${cliPath}`);
-	}
-
-	// Read the CLI file
-	let cliContent = fs.readFileSync(cliPath, "utf-8");
-
-	// Look for the version warning message
-	const warningText = "It looks like your version of Claude Code";
-	const warningIndex = cliContent.indexOf(warningText);
-
-	if (warningIndex !== -1) {
-		// Scan backwards from the warning to find "function"
-		let functionIndex = -1;
-		for (let i = warningIndex; i >= 0; i--) {
-			if (cliContent.substring(i, i + 8) === "function") {
-				functionIndex = i;
-				break;
+		if (!fs.existsSync(cliPath)) {
+			console.error(chalk.red(`CLI file not found for version ${versionOrLabel}`));
+			console.error(chalk.gray("Expected path:"), cliPath);
+			console.error(chalk.gray("Package contents:"));
+			try {
+				const packageFiles = fs.readdirSync(packageDir);
+				packageFiles.forEach((file) => console.error(chalk.gray(`  - ${file}`)));
+			} catch (_e) {
+				console.error(chalk.gray("  Could not list package directory"));
 			}
+			throw new Error(`CLI file not found at ${cliPath}`);
 		}
 
-		if (functionIndex === -1) {
-			throw new Error("Could not find function declaration before warning text");
-		}
+		let cliContent = fs.readFileSync(cliPath, "utf-8");
 
-		// Find the opening brace
-		let openBraceIndex = -1;
-		for (let i = functionIndex; i < cliContent.length; i++) {
-			if (cliContent[i] === "{") {
-				openBraceIndex = i;
-				break;
-			}
-		}
+		// FRAGILE: This patching relies on specific string patterns in cli.js
+		// If Claude Code changes the version warning format or uses minification,
+		// this may fail (acceptable - we'll see the warning in that case)
+		const warningText = "It looks like your version of Claude Code";
+		const warningIndex = cliContent.indexOf(warningText);
 
-		if (openBraceIndex === -1) {
-			throw new Error("Could not find opening brace after function declaration");
-		}
-
-		// Find the matching closing brace
-		let braceCount = 1;
-		let closeBraceIndex = -1;
-
-		for (let i = openBraceIndex + 1; i < cliContent.length; i++) {
-			if (cliContent[i] === "{") {
-				braceCount++;
-			} else if (cliContent[i] === "}") {
-				braceCount--;
-				if (braceCount === 0) {
-					closeBraceIndex = i;
+		if (warningIndex !== -1) {
+			// Scan backwards from the warning to find "function"
+			let functionIndex = -1;
+			for (let i = warningIndex; i >= 0; i--) {
+				if (cliContent.substring(i, i + 8) === "function") {
+					functionIndex = i;
 					break;
 				}
 			}
+
+			if (functionIndex === -1) {
+				throw new Error("Could not find function declaration before warning text");
+			}
+
+			// Find the opening brace
+			let openBraceIndex = -1;
+			for (let i = functionIndex; i < cliContent.length; i++) {
+				if (cliContent[i] === "{") {
+					openBraceIndex = i;
+					break;
+				}
+			}
+
+			if (openBraceIndex === -1) {
+				throw new Error("Could not find opening brace after function declaration");
+			}
+
+			// Find the matching closing brace
+			let braceCount = 1;
+			let closeBraceIndex = -1;
+
+			for (let i = openBraceIndex + 1; i < cliContent.length; i++) {
+				if (cliContent[i] === "{") {
+					braceCount++;
+				} else if (cliContent[i] === "}") {
+					braceCount--;
+					if (braceCount === 0) {
+						closeBraceIndex = i;
+						break;
+					}
+				}
+			}
+
+			if (closeBraceIndex === -1) {
+				throw new Error("Could not find matching closing brace");
+			}
+
+			// Extract the function
+			const functionDeclaration = cliContent.substring(functionIndex, openBraceIndex + 1);
+
+			// Replace the function body with an empty block
+			const patchedFunction = `${functionDeclaration} /* Version check disabled by patch */ }`;
+			cliContent =
+				cliContent.substring(0, functionIndex) + patchedFunction + cliContent.substring(closeBraceIndex + 1);
+		} else {
+			console.error(chalk.yellow(`Warning: Could not find version check to patch in version ${versionOrLabel}`));
+			console.error(chalk.gray("This version might not have the version check, continuing anyway..."));
+			// Don't throw, just continue - older versions might not have this check
 		}
 
-		if (closeBraceIndex === -1) {
-			throw new Error("Could not find matching closing brace");
-		}
-
-		// Extract the function
-		const functionDeclaration = cliContent.substring(functionIndex, openBraceIndex + 1);
-
-		// Replace the function body with an empty block
-		const patchedFunction = `${functionDeclaration} /* Version check disabled by patch */ }`;
-		cliContent = cliContent.substring(0, functionIndex) + patchedFunction + cliContent.substring(closeBraceIndex + 1);
-	} else {
-		console.error(chalk.yellow(`Warning: Could not find version check to patch in version ${version}`));
-		console.error(chalk.gray("This version might not have the version check, continuing anyway..."));
-		// Don't throw, just continue - older versions might not have this check
+		fs.writeFileSync(cliPath, cliContent);
 	}
 
-	// Write the patched file
-	fs.writeFileSync(cliPath, cliContent);
-
-	// Write empty CLAUDE.md file
-	fs.writeFileSync(path.join(tmpDir, "CLAUDE.md"), "");
-
 	try {
-		// Change to tmp directory and run claude-trace
-		process.chdir(tmpDir);
+		// Determine working directory for claude-trace
+		let workDir: string;
+		if (customBinaryPath) {
+			// Create a temp directory for custom binary execution
+			tmpDir = createTempWorkDir("claude-history-custom");
+			workDir = tmpDir;
+		} else {
+			if (!tmpDir) {
+				throw new Error("Internal error: tmpDir not initialized for npm package");
+			}
+			workDir = tmpDir;
+		}
 
-		// Capture output to only show on error
-		let _cmdOutput = "";
+		process.chdir(workDir);
+
+		// Build the claude-trace command
+		const claudePathArg = customBinaryPath ? quote([customBinaryPath]) : "./package/cli.js";
+		let additionalArgs = "";
+		if (claudeArgs) {
+			const parsed = parse(claudeArgs);
+			// Filter to only string entries for safety (reject shell operators)
+			const stringArgs = parsed.filter((entry): entry is string => typeof entry === "string");
+			additionalArgs = quote(stringArgs);
+		}
+		const command = `npx --node-options="--no-warnings" -y @mariozechner/claude-trace --claude-path ${claudePathArg} --no-open --run-with ${additionalArgs}${
+			additionalArgs ? " " : ""
+		}-p "${new Date().toISOString()} is the date. Write a haiku about it."`;
+
 		try {
-			// Use npx with -y flag to automatically confirm any prompts
-			// Use --no-open to prevent browser from opening
-			_cmdOutput = execSync(
-				`npx --node-options="--no-warnings" -y @mariozechner/claude-trace --claude-path ./package/cli.js --no-open --run-with -p "${new Date().toISOString()} is the date. Write a haiku about it."`,
-				{
-					encoding: "utf-8",
-					stdio: ["pipe", "pipe", "pipe"],
-				},
-			);
+			execSync(command, {
+				encoding: "utf-8",
+				stdio: ["pipe", "pipe", "pipe"],
+			});
 		} catch (error) {
-			console.error(chalk.red(`\nFailed to run claude-trace for version ${version}:`));
-			console.error(chalk.gray('Command: npx --node-options="--no-warnings" -y @mariozechner/claude-trace ...'));
+			console.error(
+				chalk.red(
+					`\nFailed to run claude-trace for ${customBinaryPath ? "custom binary" : `version ${versionOrLabel}`}:`,
+				),
+			);
+			console.error(chalk.gray("Command:"), command);
 			const errorObj = error as {
 				stdout?: string;
 				stderr?: string;
@@ -296,6 +367,9 @@ async function processVersion(version: string, originalCwd: string) {
 		}
 
 		// Find the generated JSONL file
+		if (!tmpDir) {
+			throw new Error("Internal error: tmpDir not initialized");
+		}
 		const claudeTraceDir = path.join(tmpDir, ".claude-trace");
 		const files = fs.readdirSync(claudeTraceDir);
 		const jsonlFile = files.find((f) => f.startsWith("log-") && f.endsWith(".jsonl"));
@@ -314,6 +388,17 @@ async function processVersion(version: string, originalCwd: string) {
 			.split("\n")
 			.filter((line) => line.trim())
 			.map((line) => JSON.parse(line));
+
+		// Debug: log all request models found
+		if (process.env.DEBUG) {
+			console.log(chalk.gray("\nDebug: Requests found in log:"));
+			data.forEach((pair, idx) => {
+				const model = pair.request?.body?.model || "unknown";
+				const toolCount = pair.request?.body?.tools?.length || 0;
+				console.log(chalk.gray(`  ${idx + 1}. Model: ${model}, Tools: ${toolCount}`));
+			});
+			console.log();
+		}
 
 		// Find requests with tools (Claude Code requests should have tools)
 		const requestsWithTools = data.filter(
@@ -400,11 +485,11 @@ async function processVersion(version: string, originalCwd: string) {
 			})
 			.join("\n\n---\n\n");
 
-		// Get release date
-		const releaseDate = getVersionReleaseDate(version);
+		// Get release date (only for npm versions)
+		const releaseDate = customBinaryPath ? "Custom Binary" : getVersionReleaseDate(versionOrLabel);
+		const versionLabel = customBinaryPath ? `Custom Binary (${outputFilename})` : versionOrLabel;
 
-		// Generate output
-		const output = `# Claude Code Version ${version}
+		const output = `# Claude Code Version ${versionLabel}
 
 Release Date: ${releaseDate}
 
@@ -421,52 +506,101 @@ ${indentHeaders(systemPrompt)}
 ${tools}
 `;
 
-		// Write to prompts-{version}.md in the original working directory
-		const outputPath = path.join(originalCwd, `prompts-${version}.md`);
 		fs.writeFileSync(outputPath, output);
 
-		console.log(chalk.green(`✓ ${version} → ${path.basename(outputPath)}`));
+		console.log(
+			chalk.green(`✓ ${customBinaryPath ? "custom binary" : versionOrLabel} → ${path.basename(outputPath)}`),
+		);
 	} finally {
 		// Change back to original directory and clean up
 		process.chdir(originalCwd);
-		if (fs.existsSync(tmpDir)) {
+		if (tmpDir && fs.existsSync(tmpDir)) {
 			fs.rmSync(tmpDir, { recursive: true, force: true });
 		}
 	}
 }
 
+/**
+ * Main entry point - parses CLI arguments and orchestrates version processing
+ * Handles both npm version extraction and custom binary analysis
+ */
 async function main() {
 	const args = process.argv.slice(2);
-	const version = args[0];
 	const fetchToLatest = args.includes("--latest");
 
-	// Get package version
+	const binaryPathIndex = args.indexOf("--binary-path");
+	const customBinaryPath =
+		binaryPathIndex !== -1 && args[binaryPathIndex + 1] && !CCHISTORY_FLAGS.includes(args[binaryPathIndex + 1])
+			? args[binaryPathIndex + 1]
+			: undefined;
+
+	if (binaryPathIndex !== -1 && !customBinaryPath) {
+		console.error(chalk.red("Error: --binary-path requires a valid path value"));
+		process.exit(1);
+	}
+
+	const claudeArgsIndex = args.indexOf("--claude-args");
+	const claudeArgs = claudeArgsIndex !== -1 && args[claudeArgsIndex + 1] ? args[claudeArgsIndex + 1] : undefined;
+
+	if (claudeArgsIndex !== -1 && !claudeArgs) {
+		console.error(chalk.red("Error: --claude-args requires a value"));
+		process.exit(1);
+	}
+
+	const version = customBinaryPath ? (args[0] && !CCHISTORY_FLAGS.includes(args[0]) ? args[0] : "custom") : args[0];
+
 	const packageJsonPath = path.join(__dirname, "..", "package.json");
 	const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"));
 
-	// Handle --version flag
 	if (args.includes("--version") || args.includes("-v")) {
 		console.log(packageJson.version);
 		process.exit(0);
 	}
 
-	// Show version at startup
 	console.log(chalk.cyan(`cchistory v${packageJson.version}`));
 	console.log();
 
-	if (!version || version.startsWith("--")) {
-		console.log(chalk.yellow("Usage: cchistory <version> [--latest]"));
+	if ((!version || CCHISTORY_FLAGS.includes(version)) && !customBinaryPath) {
+		console.log(
+			chalk.yellow('Usage: cchistory [version] [--latest] [--binary-path <path>] [--claude-args "<args>"]'),
+		);
 		console.log(chalk.gray("Examples:"));
-		console.log(chalk.gray("  cchistory 1.0.0                # Extract prompts from version 1.0.0"));
-		console.log(chalk.gray("  cchistory 1.0.0 --latest       # Extract prompts from 1.0.0 to latest"));
-		console.log(chalk.gray("  cchistory --version            # Show version"));
+		console.log(
+			chalk.gray("  cchistory 1.0.0                                          # Extract prompts from version 1.0.0"),
+		);
+		console.log(
+			chalk.gray(
+				"  cchistory 1.0.0 --latest                                 # Extract prompts from 1.0.0 to latest",
+			),
+		);
+		console.log(chalk.gray("  cchistory --binary-path /home/claude-code/cli.js         # Use custom binary"));
+		console.log(
+			chalk.gray('  cchistory --binary-path cli.js --claude-args "--debug"   # Pass args to custom binary'),
+		);
+		console.log(chalk.gray('  cchistory 1.0.0 --claude-args "--append-system-prompt"   # Pass args to npm version'));
+		console.log(chalk.gray("  cchistory --version                                      # Show version"));
 		process.exit(1);
 	}
 
-	// Store the original working directory
 	const originalCwd = process.cwd();
 
-	if (fetchToLatest) {
+	if (customBinaryPath) {
+		if (!fs.existsSync(customBinaryPath)) {
+			console.error(chalk.red(`Error: Binary path does not exist: ${customBinaryPath}`));
+			process.exit(1);
+		}
+
+		if (fetchToLatest) {
+			console.warn(chalk.yellow("Warning: --latest flag is ignored when using --binary-path"));
+			console.warn(chalk.yellow("Only the custom binary will be processed"));
+		}
+
+		if (version && version !== "custom" && !version.startsWith("--")) {
+			console.log(chalk.gray(`Note: Using label "${version}" for custom binary output`));
+		}
+	}
+
+	if (fetchToLatest && !customBinaryPath) {
 		const latestVersion = getLatestVersion();
 		console.log(chalk.blue(`Fetching versions ${version} → ${latestVersion}`));
 
@@ -475,7 +609,7 @@ async function main() {
 
 		for (const v of versions) {
 			try {
-				await processVersion(v, originalCwd);
+				await processVersion(v, originalCwd, customBinaryPath, claudeArgs);
 			} catch (error) {
 				console.error(chalk.red(`✗ ${v} failed:`));
 				console.error(chalk.gray("  Error:"), error instanceof Error ? error.message : String(error));
@@ -488,7 +622,7 @@ async function main() {
 
 		console.log(chalk.green(`\nCompleted ${versions.length} versions`));
 	} else {
-		await processVersion(version, originalCwd);
+		await processVersion(version, originalCwd, customBinaryPath, claudeArgs);
 	}
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,161 +1,27 @@
 #!/usr/bin/env node
 
-import { execSync } from "node:child_process";
-import * as fs from "node:fs";
-import * as os from "node:os";
 import * as path from "node:path";
 import chalk from "chalk";
 import { parse, quote } from "shell-quote";
+import { patchCliVersionCheck } from "./core/cli-patcher.js";
+import { extractSystemPrompt, findAndExtractUserMessage } from "./core/content-extractor.js";
+// Core imports
+import { parseJsonl } from "./core/jsonl-parser.js";
+import { formatOutput } from "./core/output-formatter.js";
+import { filterAndSortTools, hasTools, selectBestRequest } from "./core/request-filter.js";
+import { exists, readDir, readFile, writeFile } from "./services/file-service.js";
+// Service imports
+import {
+	downloadPackage,
+	getAllVersionsBetween,
+	getLatestVersion,
+	getVersionReleaseDate,
+} from "./services/npm-service.js";
+import { exec } from "./services/shell-service.js";
+import { cleanupTempDir, createTempWorkDir } from "./services/temp-service.js";
 
 /** cchistory's own flags - used for argument validation */
 const CCHISTORY_FLAGS = ["--latest", "--binary-path", "--claude-args", "--version", "-v", "--help", "-h"];
-
-interface CacheControl {
-	type: string;
-}
-
-interface InputSchema {
-	type?: string;
-	properties?: Record<string, unknown>;
-	required?: string[];
-	[key: string]: unknown;
-}
-
-interface RequestResponsePair {
-	request: {
-		timestamp: number;
-		method: string;
-		url: string;
-		headers: Record<string, string>;
-		body: {
-			model: string;
-			messages: Array<{
-				role: string;
-				content:
-					| string
-					| Array<{
-							type: string;
-							text?: string;
-							cache_control?: CacheControl;
-					  }>;
-			}>;
-			temperature?: number;
-			system?: Array<{
-				type: string;
-				text: string;
-				cache_control?: CacheControl;
-			}>;
-			tools?: Array<{
-				name: string;
-				description: string;
-				input_schema: InputSchema;
-			}>;
-		};
-	};
-	response: Record<string, unknown>;
-}
-
-function parseVersion(version: string): {
-	major: number;
-	minor: number;
-	patch: number;
-} {
-	const parts = version.split(".");
-	return {
-		major: parseInt(parts[0], 10),
-		minor: parseInt(parts[1], 10),
-		patch: parseInt(parts[2], 10),
-	};
-}
-
-function compareVersions(a: string, b: string): number {
-	const va = parseVersion(a);
-	const vb = parseVersion(b);
-
-	if (va.major !== vb.major) return va.major - vb.major;
-	if (va.minor !== vb.minor) return va.minor - vb.minor;
-	return va.patch - vb.patch;
-}
-
-function getLatestVersion(): string {
-	try {
-		const output = execSync("npm view @anthropic-ai/claude-code version", {
-			encoding: "utf-8",
-			stdio: ["pipe", "pipe", "pipe"],
-		}).trim();
-		return output;
-	} catch (error) {
-		console.error(chalk.red("Failed to fetch latest version from npm:"));
-		console.error(chalk.gray("Command: npm view @anthropic-ai/claude-code version"));
-		const errorObj = error as {
-			stdout?: string;
-			stderr?: string;
-			message?: string;
-		};
-		if (errorObj.stdout) console.error(chalk.gray("stdout:"), errorObj.stdout);
-		if (errorObj.stderr) console.error(chalk.gray("stderr:"), errorObj.stderr);
-		console.error(chalk.gray("Error:"), error instanceof Error ? error.message : String(error));
-		process.exit(1);
-	}
-}
-
-function getAllVersionsBetween(startVersion: string, endVersion: string): string[] {
-	try {
-		// Get all versions from npm
-		const output = execSync("npm view @anthropic-ai/claude-code versions --json", {
-			encoding: "utf-8",
-			stdio: ["pipe", "pipe", "pipe"],
-		});
-		const allVersions: string[] = JSON.parse(output);
-
-		// Filter versions between start and end (inclusive)
-		return allVersions
-			.filter((v) => {
-				return compareVersions(v, startVersion) >= 0 && compareVersions(v, endVersion) <= 0;
-			})
-			.sort(compareVersions);
-	} catch (error) {
-		console.error(chalk.red("Failed to fetch version list from npm:"));
-		console.error(chalk.gray("Command: npm view @anthropic-ai/claude-code versions --json"));
-		const errorObj = error as {
-			stdout?: string;
-			stderr?: string;
-			message?: string;
-		};
-		if (errorObj.stdout) console.error(chalk.gray("stdout:"), errorObj.stdout);
-		if (errorObj.stderr) console.error(chalk.gray("stderr:"), errorObj.stderr);
-		console.error(chalk.gray("Error:"), error instanceof Error ? error.message : String(error));
-		process.exit(1);
-	}
-}
-
-function getVersionReleaseDate(version: string): string {
-	try {
-		const output = execSync(`npm view @anthropic-ai/claude-code@${quote([version])} time --json`, {
-			encoding: "utf-8",
-			stdio: ["pipe", "pipe", "pipe"],
-		});
-		const times = JSON.parse(output);
-		const releaseDate = new Date(times[version]);
-		return releaseDate.toISOString().split("T")[0]; // Return YYYY-MM-DD format
-	} catch (_error) {
-		return "Unknown";
-	}
-}
-
-/**
- * Creates a temporary working directory with an empty CLAUDE.md file
- * @param prefix - Prefix for the temp directory name
- * @returns Path to the created temporary directory
- */
-function createTempWorkDir(prefix: string): string {
-	const tmpBaseDir = os.tmpdir();
-	const tmpDirName = `${prefix}-${Date.now()}-${Math.random().toString(36).substring(2, 8)}`;
-	const tmpDir = path.join(tmpBaseDir, tmpDirName);
-	fs.mkdirSync(tmpDir, { recursive: true });
-	fs.writeFileSync(path.join(tmpDir, "CLAUDE.md"), "");
-	return tmpDir;
-}
 
 /**
  * Process a single Claude Code version and extract its prompts, tools, and system messages
@@ -175,7 +41,7 @@ async function processVersion(
 		: `prompts-${versionOrLabel}.md`;
 	const outputPath = path.join(originalCwd, outputFilename);
 
-	if (fs.existsSync(outputPath)) {
+	if (exists(outputPath)) {
 		console.log(chalk.gray(`Skipping ${customBinaryPath ? "custom binary" : versionOrLabel} - already exists`));
 		return;
 	}
@@ -196,37 +62,19 @@ async function processVersion(
 		packageDir = path.join(tmpDir, "package");
 		cliPath = path.join(packageDir, "cli.js");
 
-		try {
-			execSync(`npm pack @anthropic-ai/claude-code@${quote([versionOrLabel])}`, {
-				cwd: tmpDir,
-				stdio: ["pipe", "pipe", "pipe"],
-			});
-		} catch (error) {
-			console.error(chalk.red(`Failed to download version ${versionOrLabel} from npm:`));
-			console.error(chalk.gray(`Command: npm pack @anthropic-ai/claude-code@${versionOrLabel}`));
-			const errorObj = error as {
-				stdout?: string;
-				stderr?: string;
-				message?: string;
-			};
-			if (errorObj.stdout) console.error(chalk.gray("stdout:"), errorObj.stdout);
-			if (errorObj.stderr) console.error(chalk.gray("stderr:"), errorObj.stderr);
-			console.error(chalk.gray("Error:"), error instanceof Error ? error.message : String(error));
-			throw error;
-		}
+		// Download package from npm
+		downloadPackage(versionOrLabel, tmpDir);
 
+		// Extract tarball
 		const tarFile = path.join(tmpDir, `anthropic-ai-claude-code-${versionOrLabel}.tgz`);
-		execSync(`tar -xzf ${quote([tarFile])}`, {
-			cwd: tmpDir,
-			stdio: ["pipe", "pipe", "pipe"],
-		});
+		exec(`tar -xzf ${quote([tarFile])}`, { cwd: tmpDir });
 
-		if (!fs.existsSync(cliPath)) {
+		if (!exists(cliPath)) {
 			console.error(chalk.red(`CLI file not found for version ${versionOrLabel}`));
 			console.error(chalk.gray("Expected path:"), cliPath);
 			console.error(chalk.gray("Package contents:"));
 			try {
-				const packageFiles = fs.readdirSync(packageDir);
+				const packageFiles = readDir(packageDir);
 				packageFiles.forEach((file) => console.error(chalk.gray(`  - ${file}`)));
 			} catch (_e) {
 				console.error(chalk.gray("  Could not list package directory"));
@@ -234,75 +82,16 @@ async function processVersion(
 			throw new Error(`CLI file not found at ${cliPath}`);
 		}
 
-		let cliContent = fs.readFileSync(cliPath, "utf-8");
+		// Patch version check
+		const cliContent = readFile(cliPath);
+		const patchResult = patchCliVersionCheck(cliContent);
 
-		// FRAGILE: This patching relies on specific string patterns in cli.js
-		// If Claude Code changes the version warning format or uses minification,
-		// this may fail (acceptable - we'll see the warning in that case)
-		const warningText = "It looks like your version of Claude Code";
-		const warningIndex = cliContent.indexOf(warningText);
-
-		if (warningIndex !== -1) {
-			// Scan backwards from the warning to find "function"
-			let functionIndex = -1;
-			for (let i = warningIndex; i >= 0; i--) {
-				if (cliContent.substring(i, i + 8) === "function") {
-					functionIndex = i;
-					break;
-				}
-			}
-
-			if (functionIndex === -1) {
-				throw new Error("Could not find function declaration before warning text");
-			}
-
-			// Find the opening brace
-			let openBraceIndex = -1;
-			for (let i = functionIndex; i < cliContent.length; i++) {
-				if (cliContent[i] === "{") {
-					openBraceIndex = i;
-					break;
-				}
-			}
-
-			if (openBraceIndex === -1) {
-				throw new Error("Could not find opening brace after function declaration");
-			}
-
-			// Find the matching closing brace
-			let braceCount = 1;
-			let closeBraceIndex = -1;
-
-			for (let i = openBraceIndex + 1; i < cliContent.length; i++) {
-				if (cliContent[i] === "{") {
-					braceCount++;
-				} else if (cliContent[i] === "}") {
-					braceCount--;
-					if (braceCount === 0) {
-						closeBraceIndex = i;
-						break;
-					}
-				}
-			}
-
-			if (closeBraceIndex === -1) {
-				throw new Error("Could not find matching closing brace");
-			}
-
-			// Extract the function
-			const functionDeclaration = cliContent.substring(functionIndex, openBraceIndex + 1);
-
-			// Replace the function body with an empty block
-			const patchedFunction = `${functionDeclaration} /* Version check disabled by patch */ }`;
-			cliContent =
-				cliContent.substring(0, functionIndex) + patchedFunction + cliContent.substring(closeBraceIndex + 1);
+		if (patchResult.patched) {
+			writeFile(cliPath, patchResult.content);
 		} else {
 			console.error(chalk.yellow(`Warning: Could not find version check to patch in version ${versionOrLabel}`));
 			console.error(chalk.gray("This version might not have the version check, continuing anyway..."));
-			// Don't throw, just continue - older versions might not have this check
 		}
-
-		fs.writeFileSync(cliPath, cliContent);
 	}
 
 	try {
@@ -334,44 +123,14 @@ async function processVersion(
 			additionalArgs ? " " : ""
 		}-p "${new Date().toISOString()} is the date. Write a haiku about it."`;
 
-		try {
-			execSync(command, {
-				encoding: "utf-8",
-				stdio: ["pipe", "pipe", "pipe"],
-			});
-		} catch (error) {
-			console.error(
-				chalk.red(
-					`\nFailed to run claude-trace for ${customBinaryPath ? "custom binary" : `version ${versionOrLabel}`}:`,
-				),
-			);
-			console.error(chalk.gray("Command:"), command);
-			const errorObj = error as {
-				stdout?: string;
-				stderr?: string;
-				status?: number;
-				code?: number;
-				message?: string;
-			};
-			if (errorObj.stdout) {
-				console.error(chalk.gray("stdout:"));
-				console.error(errorObj.stdout);
-			}
-			if (errorObj.stderr) {
-				console.error(chalk.gray("stderr:"));
-				console.error(errorObj.stderr);
-			}
-			console.error(chalk.gray("Error:"), error instanceof Error ? error.message : String(error));
-			console.error(chalk.gray("Exit code:"), errorObj.status || errorObj.code || "unknown");
-			throw error;
-		}
+		exec(command);
 
 		// Find the generated JSONL file
 		if (!tmpDir) {
 			throw new Error("Internal error: tmpDir not initialized");
 		}
 		const claudeTraceDir = path.join(tmpDir, ".claude-trace");
-		const files = fs.readdirSync(claudeTraceDir);
+		const files = readDir(claudeTraceDir);
 		const jsonlFile = files.find((f) => f.startsWith("log-") && f.endsWith(".jsonl"));
 
 		if (!jsonlFile) {
@@ -380,14 +139,8 @@ async function processVersion(
 
 		// Parse the JSONL file
 		const jsonlPath = path.join(claudeTraceDir, jsonlFile);
-		const jsonlContent = fs.readFileSync(jsonlPath, "utf-8");
-
-		// JSONL format: each line is a separate JSON object
-		const data: RequestResponsePair[] = jsonlContent
-			.trim()
-			.split("\n")
-			.filter((line) => line.trim())
-			.map((line) => JSON.parse(line));
+		const jsonlContent = readFile(jsonlPath);
+		const data = parseJsonl(jsonlContent);
 
 		// Debug: log all request models found
 		if (process.env.DEBUG) {
@@ -400,122 +153,49 @@ async function processVersion(
 			console.log();
 		}
 
-		// Find requests with tools (Claude Code requests should have tools)
-		const requestsWithTools = data.filter(
-			(pair) =>
-				pair.request?.body?.model &&
-				!pair.request.body.model.toLowerCase().includes("haiku") &&
-				pair.request.body.tools &&
-				Array.isArray(pair.request.body.tools) &&
-				pair.request.body.tools.length > 0,
-		);
+		// Select the best request
+		const selectedRequest = selectBestRequest(data);
 
-		let nonHaikuRequest: RequestResponsePair | undefined;
-
-		if (requestsWithTools.length === 0) {
-			// Fallback to old behavior if no requests with tools found
-			nonHaikuRequest = data.find(
-				(pair) => pair.request?.body?.model && !pair.request.body.model.toLowerCase().includes("haiku"),
-			);
-
-			if (!nonHaikuRequest) {
-				throw new Error("No non-Haiku request found in the log");
-			}
-
+		if (!hasTools(selectedRequest)) {
 			console.warn(chalk.yellow("Warning: Selected request has no tools. This may not be a Claude Code request."));
-		} else {
-			// Sort by tool count (descending) to get the most complete request
-			nonHaikuRequest = requestsWithTools.sort(
-				(a, b) => (b.request.body.tools?.length || 0) - (a.request.body.tools?.length || 0),
-			)[0];
 		}
 
 		// Extract the required information
-		const request = nonHaikuRequest.request;
+		const request = selectedRequest.request;
+		const userMessage = findAndExtractUserMessage(request.body.messages);
+		const systemPrompt = extractSystemPrompt(request.body);
 
-		// Extract user message - get all content blocks from the first user message with type safety
-		const userMessageContent = request.body.messages.find((msg) => msg.role === "user")?.content;
-		const userMessage = (() => {
-			if (!userMessageContent) return "";
+		// Filter and sort tools
+		const tools = filterAndSortTools(request.body.tools);
 
-			// Handle both string and array formats
-			if (typeof userMessageContent === "string") {
-				return userMessageContent;
-			}
-
-			if (Array.isArray(userMessageContent)) {
-				return userMessageContent
-					.filter((content) => content.type === "text")
-					.map((content) => content.text || "")
-					.join("\n");
-			}
-
-			return "";
-		})();
-
-		// Extract system prompt - join without double newlines
-		const systemPrompt = (request.body.system || [])
-			.filter((s) => s.type === "text")
-			.map((s) => s.text)
-			.join("\n");
-
-		// Function to add extra # to markdown headers
-		const indentHeaders = (text: string): string => {
-			return text
-				.split("\n")
-				.map((line) => {
-					const match = line.match(/^(#+)(\s+)/);
-					if (match) {
-						return `#${line}`;
-					}
-					return line;
-				})
-				.join("\n");
-		};
-
-		// Extract and sort tools, filtering out mcp__ tools
-		const tools = (request.body.tools || [])
-			.filter((tool) => !tool.name.startsWith("mcp__"))
-			.sort((a, b) => a.name.localeCompare(b.name))
-			.map((tool) => {
-				const schemaStr = JSON.stringify(tool.input_schema, null, 2);
-				// Apply indentation twice to make headers in tool descriptions smaller
-				const indentedDescription = indentHeaders(indentHeaders(tool.description));
-				return `## ${tool.name}\n\n${indentedDescription}\n${schemaStr}`;
-			})
-			.join("\n\n---\n\n");
-
-		// Get release date (only for npm versions)
+		// Get release date and version label
 		const releaseDate = customBinaryPath ? "Custom Binary" : getVersionReleaseDate(versionOrLabel);
 		const versionLabel = customBinaryPath ? `Custom Binary (${outputFilename})` : versionOrLabel;
 
-		const output = `# Claude Code Version ${versionLabel}
+		// Format output
+		const output = formatOutput({
+			versionLabel,
+			releaseDate,
+			userMessage,
+			systemPrompt,
+			tools,
+		});
 
-Release Date: ${releaseDate}
-
-# User Message
-
-${indentHeaders(userMessage)}
-
-# System Prompt
-
-${indentHeaders(systemPrompt)}
-
-# Tools
-
-${tools}
-`;
-
-		fs.writeFileSync(outputPath, output);
+		writeFile(outputPath, output);
 
 		console.log(
 			chalk.green(`✓ ${customBinaryPath ? "custom binary" : versionOrLabel} → ${path.basename(outputPath)}`),
 		);
+	} catch (error) {
+		console.error(
+			chalk.red(`\nFailed to process ${customBinaryPath ? "custom binary" : `version ${versionOrLabel}`}:`),
+		);
+		throw error;
 	} finally {
 		// Change back to original directory and clean up
 		process.chdir(originalCwd);
-		if (tmpDir && fs.existsSync(tmpDir)) {
-			fs.rmSync(tmpDir, { recursive: true, force: true });
+		if (tmpDir) {
+			cleanupTempDir(tmpDir);
 		}
 	}
 }
@@ -550,7 +230,7 @@ async function main() {
 	const version = customBinaryPath ? (args[0] && !CCHISTORY_FLAGS.includes(args[0]) ? args[0] : "custom") : args[0];
 
 	const packageJsonPath = path.join(__dirname, "..", "package.json");
-	const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"));
+	const packageJson = JSON.parse(readFile(packageJsonPath));
 
 	if (args.includes("--version") || args.includes("-v")) {
 		console.log(packageJson.version);
@@ -585,7 +265,7 @@ async function main() {
 	const originalCwd = process.cwd();
 
 	if (customBinaryPath) {
-		if (!fs.existsSync(customBinaryPath)) {
+		if (!exists(customBinaryPath)) {
 			console.error(chalk.red(`Error: Binary path does not exist: ${customBinaryPath}`));
 			process.exit(1);
 		}

--- a/src/services/file-service.ts
+++ b/src/services/file-service.ts
@@ -1,0 +1,59 @@
+/**
+ * Service wrapper for file system operations
+ */
+
+import * as fs from "node:fs";
+
+/**
+ * Read file contents as UTF-8 string
+ * @param filePath - Path to file
+ * @returns File contents
+ */
+export function readFile(filePath: string): string {
+	return fs.readFileSync(filePath, "utf-8");
+}
+
+/**
+ * Write content to file
+ * @param filePath - Path to file
+ * @param content - Content to write
+ */
+export function writeFile(filePath: string, content: string): void {
+	fs.writeFileSync(filePath, content, "utf-8");
+}
+
+/**
+ * Check if file or directory exists
+ * @param filePath - Path to check
+ * @returns True if exists
+ */
+export function exists(filePath: string): boolean {
+	return fs.existsSync(filePath);
+}
+
+/**
+ * Create directory (with recursive option)
+ * @param dirPath - Directory path
+ */
+export function createDir(dirPath: string): void {
+	fs.mkdirSync(dirPath, { recursive: true });
+}
+
+/**
+ * Remove directory recursively
+ * @param dirPath - Directory path
+ */
+export function removeDir(dirPath: string): void {
+	if (fs.existsSync(dirPath)) {
+		fs.rmSync(dirPath, { recursive: true, force: true });
+	}
+}
+
+/**
+ * Read directory contents
+ * @param dirPath - Directory path
+ * @returns Array of file/directory names
+ */
+export function readDir(dirPath: string): string[] {
+	return fs.readdirSync(dirPath);
+}

--- a/src/services/npm-service.ts
+++ b/src/services/npm-service.ts
@@ -1,0 +1,113 @@
+/**
+ * Service wrapper for npm operations
+ */
+
+import { execSync } from "node:child_process";
+import chalk from "chalk";
+import { quote } from "shell-quote";
+import { compareVersions } from "../core/version-utils.js";
+
+/**
+ * Get the latest published version of Claude Code from npm
+ * @returns Latest version string
+ */
+export function getLatestVersion(): string {
+	try {
+		const output = execSync("npm view @anthropic-ai/claude-code version", {
+			encoding: "utf-8",
+			stdio: ["pipe", "pipe", "pipe"],
+		}).trim();
+		return output;
+	} catch (error) {
+		console.error(chalk.red("Failed to fetch latest version from npm:"));
+		console.error(chalk.gray("Command: npm view @anthropic-ai/claude-code version"));
+		const errorObj = error as {
+			stdout?: string;
+			stderr?: string;
+			message?: string;
+		};
+		if (errorObj.stdout) console.error(chalk.gray("stdout:"), errorObj.stdout);
+		if (errorObj.stderr) console.error(chalk.gray("stderr:"), errorObj.stderr);
+		console.error(chalk.gray("Error:"), error instanceof Error ? error.message : String(error));
+		process.exit(1);
+	}
+}
+
+/**
+ * Get all versions between start and end (inclusive)
+ * @param startVersion - Starting version
+ * @param endVersion - Ending version
+ * @returns Sorted array of versions
+ */
+export function getAllVersionsBetween(startVersion: string, endVersion: string): string[] {
+	try {
+		const output = execSync("npm view @anthropic-ai/claude-code versions --json", {
+			encoding: "utf-8",
+			stdio: ["pipe", "pipe", "pipe"],
+		});
+		const allVersions: string[] = JSON.parse(output);
+
+		return allVersions
+			.filter((v) => {
+				return compareVersions(v, startVersion) >= 0 && compareVersions(v, endVersion) <= 0;
+			})
+			.sort(compareVersions);
+	} catch (error) {
+		console.error(chalk.red("Failed to fetch version list from npm:"));
+		console.error(chalk.gray("Command: npm view @anthropic-ai/claude-code versions --json"));
+		const errorObj = error as {
+			stdout?: string;
+			stderr?: string;
+			message?: string;
+		};
+		if (errorObj.stdout) console.error(chalk.gray("stdout:"), errorObj.stdout);
+		if (errorObj.stderr) console.error(chalk.gray("stderr:"), errorObj.stderr);
+		console.error(chalk.gray("Error:"), error instanceof Error ? error.message : String(error));
+		process.exit(1);
+	}
+}
+
+/**
+ * Get release date for a specific version
+ * @param version - Version to look up
+ * @returns Release date in YYYY-MM-DD format, or "Unknown" if not found
+ */
+export function getVersionReleaseDate(version: string): string {
+	try {
+		const output = execSync(`npm view @anthropic-ai/claude-code@${quote([version])} time --json`, {
+			encoding: "utf-8",
+			stdio: ["pipe", "pipe", "pipe"],
+		});
+		const times = JSON.parse(output);
+		const releaseDate = new Date(times[version]);
+		return releaseDate.toISOString().split("T")[0];
+	} catch (_error) {
+		return "Unknown";
+	}
+}
+
+/**
+ * Download a specific version using npm pack
+ * @param version - Version to download
+ * @param targetDir - Directory to download into
+ */
+export function downloadPackage(version: string, targetDir: string): void {
+	try {
+		execSync(`npm pack @anthropic-ai/claude-code@${quote([version])}`, {
+			cwd: targetDir,
+			stdio: ["pipe", "pipe", "pipe"],
+		});
+	} catch (error) {
+		console.error(chalk.red(`Failed to download version ${version} from npm:`));
+		console.error(chalk.gray(`Command: npm pack @anthropic-ai/claude-code@${version}`));
+		const errorObj = error as {
+			stdout?: string;
+			stderr?: string;
+			message?: string;
+		};
+		if (errorObj.stdout) console.error(chalk.gray("stdout:"), errorObj.stdout);
+		if (errorObj.stderr) console.error(chalk.gray("stderr:"), errorObj.stderr);
+		console.error(chalk.gray("Error:"), error instanceof Error ? error.message : String(error));
+		throw error;
+	}
+}

--- a/src/services/shell-service.ts
+++ b/src/services/shell-service.ts
@@ -1,0 +1,62 @@
+/**
+ * Service wrapper for shell command execution
+ */
+
+import { execSync } from "node:child_process";
+import chalk from "chalk";
+
+export interface ExecOptions {
+	cwd?: string;
+	encoding?: BufferEncoding;
+}
+
+/**
+ * Execute a shell command and return output
+ * @param command - Command to execute
+ * @param options - Execution options
+ * @returns Command output as string
+ */
+export function exec(command: string, options?: ExecOptions): string {
+	try {
+		return execSync(command, {
+			encoding: options?.encoding || "utf-8",
+			stdio: ["pipe", "pipe", "pipe"],
+			cwd: options?.cwd,
+		}) as string;
+	} catch (error) {
+		console.error(chalk.red(`Failed to execute command:`));
+		console.error(chalk.gray("Command:"), command);
+		const errorObj = error as {
+			stdout?: string;
+			stderr?: string;
+			status?: number;
+			code?: number;
+			message?: string;
+		};
+		if (errorObj.stdout) {
+			console.error(chalk.gray("stdout:"));
+			console.error(errorObj.stdout);
+		}
+		if (errorObj.stderr) {
+			console.error(chalk.gray("stderr:"));
+			console.error(errorObj.stderr);
+		}
+		console.error(chalk.gray("Error:"), error instanceof Error ? error.message : String(error));
+		console.error(chalk.gray("Exit code:"), errorObj.status || errorObj.code || "unknown");
+		throw error;
+	}
+}
+
+/**
+ * Execute a shell command silently (suppresses output in case of error)
+ * @param command - Command to execute
+ * @param options - Execution options
+ * @returns Command output as string
+ */
+export function execSilent(command: string, options?: ExecOptions): string {
+	return execSync(command, {
+		encoding: options?.encoding || "utf-8",
+		stdio: ["pipe", "pipe", "pipe"],
+		cwd: options?.cwd,
+	}) as string;
+}

--- a/src/services/temp-service.ts
+++ b/src/services/temp-service.ts
@@ -1,0 +1,31 @@
+/**
+ * Service wrapper for temporary directory management
+ */
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+/**
+ * Create a temporary working directory with an empty CLAUDE.md file
+ * @param prefix - Prefix for the temp directory name
+ * @returns Path to the created temporary directory
+ */
+export function createTempWorkDir(prefix: string): string {
+	const tmpBaseDir = os.tmpdir();
+	const tmpDirName = `${prefix}-${Date.now()}-${Math.random().toString(36).substring(2, 8)}`;
+	const tmpDir = path.join(tmpBaseDir, tmpDirName);
+	fs.mkdirSync(tmpDir, { recursive: true });
+	fs.writeFileSync(path.join(tmpDir, "CLAUDE.md"), "");
+	return tmpDir;
+}
+
+/**
+ * Clean up a temporary directory
+ * @param tmpDir - Directory to remove
+ */
+export function cleanupTempDir(tmpDir: string): void {
+	if (fs.existsSync(tmpDir)) {
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	}
+}

--- a/src/types/request.ts
+++ b/src/types/request.ts
@@ -1,0 +1,58 @@
+/**
+ * Type definitions for Claude API request/response pairs
+ */
+
+export interface CacheControl {
+	type: string;
+}
+
+export interface InputSchema {
+	type?: string;
+	properties?: Record<string, unknown>;
+	required?: string[];
+	[key: string]: unknown;
+}
+
+export interface Tool {
+	name: string;
+	description: string;
+	input_schema: InputSchema;
+}
+
+export interface MessageContent {
+	type: string;
+	text?: string;
+	cache_control?: CacheControl;
+}
+
+export interface Message {
+	role: string;
+	content: string | MessageContent[];
+}
+
+export interface SystemBlock {
+	type: string;
+	text: string;
+	cache_control?: CacheControl;
+}
+
+export interface RequestBody {
+	model: string;
+	messages: Message[];
+	temperature?: number;
+	system?: SystemBlock[];
+	tools?: Tool[];
+}
+
+export interface Request {
+	timestamp: number;
+	method: string;
+	url: string;
+	headers: Record<string, string>;
+	body: RequestBody;
+}
+
+export interface RequestResponsePair {
+	request: Request;
+	response: Record<string, unknown>;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html', 'lcov'],
+      include: ['src/**/*.ts'],
+      exclude: [
+        'src/**/*.test.ts',
+        'src/**/*.spec.ts',
+        'src/services/**',      // Thin wrappers, little value in unit testing
+        'src/index.ts',         // Orchestration layer, better tested via E2E
+        'src/types/**',         // Type definitions only
+        'dist/**'
+      ],
+      all: true,
+      thresholds: {
+        lines: 100,
+        functions: 100,
+        branches: 95,           // Allow minor flexibility for edge cases
+        statements: 100
+      }
+    },
+    mockReset: true,
+    unstubEnvs: true,
+    unstubGlobals: true,
+    environment: 'node'
+  }
+})


### PR DESCRIPTION
## Summary

This PR combines two major improvements:
1. Adds support for testing custom/local Claude Code binaries and passing additional CLI arguments (#3)
2. Fixes critical bugs in request parsing that caused TypeErrors and incorrect prompt extraction (#4)

## Motivation

**Issue #3**: Developers working on Claude Code forks or local modifications need a way to extract and compare prompts from their builds without publishing to npm.

**Issue #4**: cchistory was crashing with TypeErrors when message content was a string instead of array, and was sometimes extracting prompts from internal test requests instead of actual Claude Code requests.

Closes #3
Closes #4

## Changes

### New Features (#3)
- **`--binary-path <path>`**: Test custom Claude Code binaries directly without npm download
- **`--claude-args "<args>"`**: Pass additional CLI arguments to Claude Code during execution
- **Security**: Add `shell-quote` library for safe command escaping and injection prevention
- **Debug mode**: Support `DEBUG=1` environment variable for detailed logging

### Bug Fixes (#4)
- **TypeError fix**: Update `RequestResponsePair` interface to handle both string and array content formats
- **Request selection**: Filter for requests with tools and sort by tool count to identify actual Claude Code requests
- **Type safety**: Add runtime type guards for safe content extraction
- **Backward compatibility**: Maintain fallback behavior for edge cases

### Code Changes
- Add `createTempWorkDir()` utility function for better code organization
- Refactor `processVersion()` to support both npm versions and custom binaries
- Generate timestamped output files for custom binaries (`prompts-custom-*.md`)
- Filter shell operators from `--claude-args` for security
- Fix unused `_cmdOutput` variable (TypeScript warning)
- Add proper type guards for message content handling

### Documentation
- Update Usage section with new flags, options, and examples
- Add comprehensive Advanced Usage section covering:
  - Testing local/development builds
  - Passing arguments to Claude Code
  - Debugging techniques
  - Security notes
- Split "How it works" into Standard Mode vs Custom Binary Mode
- Update Prerequisites to clarify optional Claude Code installation

## Usage Examples

```bash
# Test a custom/local build
cchistory --binary-path /path/to/custom/cli.js

# Test with additional arguments
cchistory 1.0.0 --claude-args "--mcp-config /path/to/config.json"

# Combine both
cchistory --binary-path ./build/cli.js --claude-args "--verbose"

# Debug mode to see all requests
DEBUG=1 cchistory 1.0.0
```

## Testing

### Issue #3 (Custom Binary Support)
- [x] Tested with npm versions
- [x] Tested with custom binary path
- [x] Tested with `--claude-args` flag
- [x] Verified shell escaping with special characters
- [x] Confirmed TypeScript warning is resolved
- [x] Documentation examples verified

### Issue #4 (Request Parsing)
- [x] Tested with string content format (older Claude Code versions)
- [x] Tested with array content format (newer Claude Code versions)
- [x] Verified correct request selection (requests with tools are prioritized)
- [x] Confirmed fallback behavior works when no tools are present
- [x] No TypeErrors when processing various log formats

## Technical Details

### Issue #4 - Request Parsing Improvements

**Problem 1: Content Type Mismatch**
```typescript
// Before: Assumed content was always an array
content: Array<{ type: string; text?: string; }>

// After: Handles both string and array formats
content: string | Array<{ type: string; text?: string; }>
```

**Problem 2: Wrong Request Selected**
- Previously: Selected first non-Haiku request (could be internal test data)
- Now: Filters for requests with tools, sorts by tool count (descending)
- Result: Always selects the actual Claude Code request with full tool list

**Type Guard Implementation**
```typescript
const userMessage = (() => {
  if (!userMessageContent) return "";
  if (typeof userMessageContent === "string") return userMessageContent;
  if (Array.isArray(userMessageContent)) {
    return userMessageContent
      .filter((content) => content.type === "text")
      .map((content) => content.text || "")
      .join("\n");
  }
  return "";
})();
```

### Issue #3 - Custom Binary Architecture

**Decision: Direct Execution vs Patching**
- Custom binaries are executed directly without modification
- npm packages still get version check patching
- Separate temp directories for each execution mode
- Timestamped output files prevent conflicts

## Security Considerations

- All shell commands use proper escaping via `shell-quote` library
- The `--claude-args` parameter filters out shell operators for safety
- Custom binaries are executed directly without modification
- Version patching only modifies the version check function
- No eval() or unsafe string interpolation

## Breaking Changes

None. All changes are backwards compatible. Existing usage patterns continue to work.

## Commits Included

1. `74aae76` - Fixed #4: Request parsing and type safety improvements
2. `1466439` - Add custom binary support and argument passing (#3)

## Related Issues

- Closes #3: https://github.com/badlogic/cchistory/issues/3
- Closes #4: https://github.com/badlogic/cchistory/issues/4

(Updated description, I accidentally merged the pull requests, don't normally do that by the GitHub.com interface, my bad!)