### PR TITLE
Prioritize system prompts and add Claude Code 2.0.24+ compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,16 @@ cchistory --binary-path ./build/cli.js --claude-args "--verbose"
 cchistory 1.5.0 --claude-args "--append-system-prompt"
 ```
 
+## Claude Code Version Compatibility
+
+| Version | Changes | cchistory Support |
+|---------|---------|-------------------|
+| ≤ 2.0.5 | Array message format, complete system prompts | ✅ All versions |
+| 2.0.8 - 2.0.23 | System prompts sometimes missing | ⚠️ Use latest (prioritizes system prompts) |
+| ≥ 2.0.24 | String message format | ✅ Requires v1.2.0+ (v1.1.9 fails [#6](https://github.com/badlogic/cchistory/issues/6)) |
+
+**Note:** Versions 2.0.4, 2.0.6, 2.0.7, and 2.0.16 were not published to npm.
+
 ## How it works
 
 ### Standard Mode (NPM versions)

--- a/src/core/cli-args.test.ts
+++ b/src/core/cli-args.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Tests for CLI argument parsing, specifically --binary-path and --claude-args
+ */
+
+import { parse, quote } from "shell-quote";
+import { describe, expect, it } from "vitest";
+
+describe("CLI Arguments Parsing", () => {
+	describe("--binary-path argument parsing", () => {
+		it("extracts binary path from args", () => {
+			const args = ["--binary-path", "/path/to/cli.js"];
+			const binaryPathIndex = args.indexOf("--binary-path");
+			const customBinaryPath = binaryPathIndex !== -1 ? args[binaryPathIndex + 1] : undefined;
+
+			expect(customBinaryPath).toBe("/path/to/cli.js");
+		});
+
+		it("handles missing binary path value", () => {
+			const args = ["--binary-path"];
+			const CCHISTORY_FLAGS = ["--latest", "--binary-path", "--claude-args", "--version", "-v", "--help", "-h"];
+			const binaryPathIndex = args.indexOf("--binary-path");
+			const customBinaryPath =
+				binaryPathIndex !== -1 && args[binaryPathIndex + 1] && !CCHISTORY_FLAGS.includes(args[binaryPathIndex + 1])
+					? args[binaryPathIndex + 1]
+					: undefined;
+
+			expect(customBinaryPath).toBeUndefined();
+		});
+
+		it("handles binary path followed by another flag", () => {
+			const args = ["--binary-path", "--latest"];
+			const CCHISTORY_FLAGS = ["--latest", "--binary-path", "--claude-args", "--version", "-v", "--help", "-h"];
+			const binaryPathIndex = args.indexOf("--binary-path");
+			const customBinaryPath =
+				binaryPathIndex !== -1 && args[binaryPathIndex + 1] && !CCHISTORY_FLAGS.includes(args[binaryPathIndex + 1])
+					? args[binaryPathIndex + 1]
+					: undefined;
+
+			expect(customBinaryPath).toBeUndefined();
+		});
+
+		it("handles relative path", () => {
+			const args = ["--binary-path", "./cli.js"];
+			const binaryPathIndex = args.indexOf("--binary-path");
+			const customBinaryPath = binaryPathIndex !== -1 ? args[binaryPathIndex + 1] : undefined;
+
+			expect(customBinaryPath).toBe("./cli.js");
+		});
+
+		it("handles absolute path", () => {
+			const args = ["--binary-path", "/usr/local/bin/claude-code"];
+			const binaryPathIndex = args.indexOf("--binary-path");
+			const customBinaryPath = binaryPathIndex !== -1 ? args[binaryPathIndex + 1] : undefined;
+
+			expect(customBinaryPath).toBe("/usr/local/bin/claude-code");
+		});
+	});
+
+	describe("--claude-args argument parsing", () => {
+		it("extracts claude args from args array", () => {
+			const args = ["--claude-args", "--debug"];
+			const claudeArgsIndex = args.indexOf("--claude-args");
+			const claudeArgs = claudeArgsIndex !== -1 && args[claudeArgsIndex + 1] ? args[claudeArgsIndex + 1] : undefined;
+
+			expect(claudeArgs).toBe("--debug");
+		});
+
+		it("handles missing claude args value", () => {
+			const args = ["--claude-args"];
+			const claudeArgsIndex = args.indexOf("--claude-args");
+			const claudeArgs = claudeArgsIndex !== -1 && args[claudeArgsIndex + 1] ? args[claudeArgsIndex + 1] : undefined;
+
+			expect(claudeArgs).toBeUndefined();
+		});
+
+		it("handles multiple arguments in a single string", () => {
+			const args = ["--claude-args", "--debug --verbose"];
+			const claudeArgsIndex = args.indexOf("--claude-args");
+			const claudeArgs = claudeArgsIndex !== -1 && args[claudeArgsIndex + 1] ? args[claudeArgsIndex + 1] : undefined;
+
+			expect(claudeArgs).toBe("--debug --verbose");
+		});
+	});
+
+	describe("shell-quote security filtering", () => {
+		it("filters shell operators from claude-args", () => {
+			const claudeArgs = "--debug && rm -rf /";
+			const parsed = parse(claudeArgs);
+			const stringArgs = parsed.filter((entry): entry is string => typeof entry === "string");
+
+			// Shell operators should be filtered out
+			expect(stringArgs).not.toContain("&&");
+			expect(stringArgs).toEqual(["--debug", "rm", "-rf", "/"]);
+		});
+
+		it("handles safe arguments correctly", () => {
+			const claudeArgs = "--debug --verbose --config /path/to/config.json";
+			const parsed = parse(claudeArgs);
+			const stringArgs = parsed.filter((entry): entry is string => typeof entry === "string");
+
+			expect(stringArgs).toEqual(["--debug", "--verbose", "--config", "/path/to/config.json"]);
+		});
+
+		it("filters pipe operators", () => {
+			const claudeArgs = "--debug | cat";
+			const parsed = parse(claudeArgs);
+			const stringArgs = parsed.filter((entry): entry is string => typeof entry === "string");
+
+			expect(stringArgs).not.toContain("|");
+			expect(stringArgs).toEqual(["--debug", "cat"]);
+		});
+
+		it("filters redirect operators", () => {
+			const claudeArgs = "--debug > output.txt";
+			const parsed = parse(claudeArgs);
+			const stringArgs = parsed.filter((entry): entry is string => typeof entry === "string");
+
+			expect(stringArgs).not.toContain(">");
+			expect(stringArgs).toEqual(["--debug", "output.txt"]);
+		});
+
+		it("filters semicolon separators", () => {
+			const claudeArgs = "--debug; echo malicious";
+			const parsed = parse(claudeArgs);
+			const stringArgs = parsed.filter((entry): entry is string => typeof entry === "string");
+
+			expect(stringArgs).not.toContain(";");
+			expect(stringArgs).toEqual(["--debug", "echo", "malicious"]);
+		});
+
+		it("properly quotes filtered arguments", () => {
+			const claudeArgs = "--config /path/to/config.json --debug";
+			const parsed = parse(claudeArgs);
+			const stringArgs = parsed.filter((entry): entry is string => typeof entry === "string");
+			const quoted = quote(stringArgs);
+
+			// Should be properly quoted for safe shell execution
+			expect(quoted).toBeTruthy();
+			expect(typeof quoted).toBe("string");
+		});
+
+		it("handles arguments with spaces", () => {
+			const claudeArgs = '--message "test message with spaces"';
+			const parsed = parse(claudeArgs);
+			const stringArgs = parsed.filter((entry): entry is string => typeof entry === "string");
+
+			expect(stringArgs).toContain("--message");
+			expect(stringArgs).toContain("test message with spaces");
+		});
+
+		it("handles empty string", () => {
+			const claudeArgs = "";
+			const parsed = parse(claudeArgs);
+			const stringArgs = parsed.filter((entry): entry is string => typeof entry === "string");
+
+			expect(stringArgs).toEqual([]);
+		});
+	});
+
+	describe("Combined argument scenarios", () => {
+		it("handles --binary-path and --claude-args together", () => {
+			const args = ["--binary-path", "/path/to/cli.js", "--claude-args", "--debug"];
+
+			const binaryPathIndex = args.indexOf("--binary-path");
+			const customBinaryPath = binaryPathIndex !== -1 ? args[binaryPathIndex + 1] : undefined;
+
+			const claudeArgsIndex = args.indexOf("--claude-args");
+			const claudeArgs = claudeArgsIndex !== -1 && args[claudeArgsIndex + 1] ? args[claudeArgsIndex + 1] : undefined;
+
+			expect(customBinaryPath).toBe("/path/to/cli.js");
+			expect(claudeArgs).toBe("--debug");
+		});
+
+		it("handles version with --claude-args", () => {
+			const args = ["1.0.0", "--claude-args", "--append-system-prompt"];
+
+			const CCHISTORY_FLAGS = ["--latest", "--binary-path", "--claude-args", "--version", "-v", "--help", "-h"];
+			const version = args[0] && !CCHISTORY_FLAGS.includes(args[0]) ? args[0] : undefined;
+
+			const claudeArgsIndex = args.indexOf("--claude-args");
+			const claudeArgs = claudeArgsIndex !== -1 && args[claudeArgsIndex + 1] ? args[claudeArgsIndex + 1] : undefined;
+
+			expect(version).toBe("1.0.0");
+			expect(claudeArgs).toBe("--append-system-prompt");
+		});
+
+		it("handles all arguments together", () => {
+			const args = ["1.0.0", "--latest", "--claude-args", "--debug --verbose"];
+
+			const CCHISTORY_FLAGS = ["--latest", "--binary-path", "--claude-args", "--version", "-v", "--help", "-h"];
+			const version = args[0] && !CCHISTORY_FLAGS.includes(args[0]) ? args[0] : undefined;
+			const fetchToLatest = args.includes("--latest");
+			const claudeArgsIndex = args.indexOf("--claude-args");
+			const claudeArgs = claudeArgsIndex !== -1 && args[claudeArgsIndex + 1] ? args[claudeArgsIndex + 1] : undefined;
+
+			expect(version).toBe("1.0.0");
+			expect(fetchToLatest).toBe(true);
+			expect(claudeArgs).toBe("--debug --verbose");
+		});
+	});
+
+	describe("Path quoting for command construction", () => {
+		it("safely quotes binary path with spaces", () => {
+			const binaryPath = "/path with spaces/cli.js";
+			const quoted = quote([binaryPath]);
+
+			expect(quoted).toBe("'/path with spaces/cli.js'");
+		});
+
+		it("safely quotes simple path", () => {
+			const binaryPath = "/path/to/cli.js";
+			const quoted = quote([binaryPath]);
+
+			expect(quoted).toBe("/path/to/cli.js");
+		});
+
+		it("handles paths with special characters", () => {
+			const binaryPath = "/path/to/cli's-file.js";
+			const quoted = quote([binaryPath]);
+
+			// Should be properly escaped
+			expect(quoted).toBeTruthy();
+		});
+	});
+});

--- a/src/core/command-construction.test.ts
+++ b/src/core/command-construction.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Tests for command construction with various argument combinations
+ * Verifies that commands are properly constructed according to README examples
+ */
+
+import { parse, quote } from "shell-quote";
+import { describe, expect, it } from "vitest";
+
+describe("Command Construction", () => {
+	/**
+	 * Helper function that simulates the command construction logic from index.ts
+	 */
+	function constructCommand(customBinaryPath: string | undefined, claudeArgs: string | undefined): string {
+		const claudePathArg = customBinaryPath ? quote([customBinaryPath]) : "./package/cli.js";
+		let additionalArgs = "";
+		if (claudeArgs) {
+			const parsed = parse(claudeArgs);
+			const stringArgs = parsed.filter((entry): entry is string => typeof entry === "string");
+			additionalArgs = quote(stringArgs);
+		}
+		const command = `npx --node-options="--no-warnings" -y @mariozechner/claude-trace --claude-path ${claudePathArg} --no-open --run-with ${additionalArgs}${
+			additionalArgs ? " " : ""
+		}-p "${new Date().toISOString()} is the date. Write a haiku about it."`;
+		return command;
+	}
+
+	describe("README Example 1: Extract from single version", () => {
+		it("constructs command for npm package without custom args", () => {
+			const command = constructCommand(undefined, undefined);
+
+			expect(command).toContain("@mariozechner/claude-trace");
+			expect(command).toContain("--claude-path ./package/cli.js");
+			expect(command).toContain("--no-open");
+			expect(command).toContain("--run-with");
+			expect(command).toContain('-p "');
+			expect(command).toContain("Write a haiku about it");
+		});
+	});
+
+	describe("README Example 3: Test custom/local build", () => {
+		it("constructs command with custom binary path", () => {
+			const command = constructCommand("/path/to/custom/cli.js", undefined);
+
+			expect(command).toContain("--claude-path /path/to/custom/cli.js");
+			expect(command).not.toContain("./package/cli.js");
+		});
+
+		it("properly quotes binary path with spaces", () => {
+			const command = constructCommand("/path with spaces/cli.js", undefined);
+
+			expect(command).toContain("--claude-path '/path with spaces/cli.js'");
+		});
+
+		it("handles relative path", () => {
+			const command = constructCommand("./build/cli.js", undefined);
+
+			expect(command).toContain("--claude-path ./build/cli.js");
+		});
+	});
+
+	describe("README Example 4: Test with additional arguments", () => {
+		it("constructs command with claude args for npm version", () => {
+			const command = constructCommand(undefined, "--mcp-config /path/to/config.json");
+
+			expect(command).toContain("--run-with --mcp-config /path/to/config.json -p");
+		});
+
+		it("handles multiple claude args", () => {
+			const command = constructCommand(undefined, "--debug --verbose");
+
+			expect(command).toContain("--run-with --debug --verbose -p");
+		});
+	});
+
+	describe("README Example 5: Combine custom binary with custom arguments", () => {
+		it("constructs command with both custom binary and args", () => {
+			const command = constructCommand("./build/cli.js", "--verbose");
+
+			expect(command).toContain("--claude-path ./build/cli.js");
+			expect(command).toContain("--run-with --verbose -p");
+		});
+
+		it("handles complex combination", () => {
+			const command = constructCommand("/custom/path/cli.js", "--debug --config test.json");
+
+			expect(command).toContain("--claude-path /custom/path/cli.js");
+			expect(command).toContain("--run-with --debug --config test.json -p");
+		});
+	});
+
+	describe("README Example 6: Pass system prompt modifiers", () => {
+		it("constructs command with system prompt modifier", () => {
+			const command = constructCommand(undefined, "--append-system-prompt");
+
+			expect(command).toContain("--run-with --append-system-prompt -p");
+		});
+	});
+
+	describe("Security: Shell injection prevention", () => {
+		it("filters shell operators from claude args", () => {
+			const command = constructCommand(undefined, "--debug && rm -rf /");
+
+			// The command should not contain '&&' as a shell operator
+			// It will be filtered by parse() and the args will be quoted
+			expect(command).toContain("--run-with");
+			// The filtered result should only contain safe arguments
+			expect(command).not.toContain("&& ");
+		});
+
+		it("filters pipe operators", () => {
+			const command = constructCommand(undefined, "--debug | cat /etc/passwd");
+
+			// Should not contain pipe as a shell operator
+			expect(command).not.toContain("| ");
+		});
+
+		it("filters redirect operators", () => {
+			const command = constructCommand(undefined, "--debug > malicious.txt");
+
+			// Should not contain redirect as a shell operator
+			expect(command).not.toContain("> ");
+		});
+
+		it("filters semicolon separators", () => {
+			const command = constructCommand(undefined, "--debug; echo malicious");
+
+			// Should not contain semicolon as a shell operator
+			expect(command).not.toContain("; ");
+		});
+
+		it("safely handles binary path with special characters", () => {
+			const command = constructCommand("/path/with/special's/cli.js", undefined);
+
+			// Path should be properly quoted
+			expect(command).toContain("--claude-path");
+			// Should not break the command structure
+			expect(command).toContain("@mariozechner/claude-trace");
+		});
+	});
+
+	describe("Edge cases", () => {
+		it("handles empty claude args", () => {
+			const command = constructCommand(undefined, "");
+
+			// Should work fine with empty string (note: single space between --run-with and -p)
+			expect(command).toContain("--run-with -p");
+			expect(command).toContain("@mariozechner/claude-trace");
+		});
+
+		it("handles single argument", () => {
+			const command = constructCommand(undefined, "--debug");
+
+			expect(command).toContain("--run-with --debug -p");
+		});
+
+		it("handles arguments with equals sign", () => {
+			const command = constructCommand(undefined, "--config=test.json");
+
+			// shell-quote escapes the equals sign for safety
+			expect(command).toContain("--run-with");
+			expect(command).toContain("--config");
+			expect(command).toContain("test.json");
+		});
+
+		it("preserves quoted arguments in claude args", () => {
+			const command = constructCommand(undefined, '--message "hello world"');
+
+			expect(command).toContain("--run-with");
+			// The quoted content should be preserved through parse/quote
+			expect(command).toContain("hello world");
+		});
+	});
+
+	describe("Command structure validation", () => {
+		it("always includes required npx flags", () => {
+			const command = constructCommand(undefined, undefined);
+
+			expect(command).toMatch(/^npx --node-options="--no-warnings" -y/);
+		});
+
+		it("always includes claude-trace package", () => {
+			const command = constructCommand(undefined, undefined);
+
+			expect(command).toContain("@mariozechner/claude-trace");
+		});
+
+		it("always includes --no-open flag", () => {
+			const command = constructCommand(undefined, undefined);
+
+			expect(command).toContain("--no-open");
+		});
+
+		it("always includes --run-with flag", () => {
+			const command = constructCommand(undefined, undefined);
+
+			expect(command).toContain("--run-with");
+		});
+
+		it("always includes the test prompt", () => {
+			const command = constructCommand(undefined, undefined);
+
+			expect(command).toContain("Write a haiku about it");
+		});
+
+		it("maintains proper argument order", () => {
+			const command = constructCommand("/path/cli.js", "--debug");
+
+			// Verify the order: npx ... claude-trace --claude-path ... --no-open --run-with ... -p "..."
+			expect(command).toMatch(/npx.*claude-trace.*--claude-path.*--no-open.*--run-with.*-p.*Write a haiku about it/);
+		});
+	});
+});

--- a/src/core/content-extractor.ts
+++ b/src/core/content-extractor.ts
@@ -15,12 +15,10 @@ export function extractUserMessage(message: Message | undefined): string {
 
 	const content = message.content;
 
-	// Handle string format
 	if (typeof content === "string") {
 		return content;
 	}
 
-	// Handle array format
 	if (Array.isArray(content)) {
 		return content
 			.filter((item) => item.type === "text")

--- a/src/core/integration.test.ts
+++ b/src/core/integration.test.ts
@@ -1,0 +1,347 @@
+/**
+ * Integration tests for the full extraction flow
+ * Tests the complete path: JSONL parsing → request selection → content extraction
+ */
+
+import { describe, expect, it } from "vitest";
+import type { RequestResponsePair } from "../types/request.js";
+import { extractSystemPrompt, findAndExtractUserMessage } from "./content-extractor.js";
+import { selectBestRequest } from "./request-filter.js";
+
+describe("E2E Integration - Full Extraction Flow", () => {
+	it("handles Claude Code 2.0.24+ string content format end-to-end", () => {
+		// Simulate the actual JSONL log data from Claude Code 2.0.24+
+		const mockJsonlData: RequestResponsePair[] = [
+			{
+				request: {
+					timestamp: 1,
+					method: "POST",
+					url: "/v1/messages",
+					headers: {},
+					body: {
+						model: "claude-3-haiku-20240307",
+						messages: [
+							{
+								role: "user",
+								content: "Check quota", // String format (Haiku quota check)
+							},
+						],
+					},
+				},
+				response: {},
+			},
+			{
+				request: {
+					timestamp: 2,
+					method: "POST",
+					url: "/v1/messages",
+					headers: {},
+					body: {
+						model: "claude-3-5-sonnet-20241022",
+						messages: [
+							{
+								role: "user",
+								content: "Write a haiku about the date", // String format (actual user message)
+							},
+						],
+						system: [
+							{
+								type: "text",
+								text: "You are Claude Code, an AI assistant.",
+							},
+						],
+						tools: [
+							{
+								name: "Read",
+								description: "Read a file",
+								input_schema: { type: "object" },
+							},
+							{
+								name: "Write",
+								description: "Write a file",
+								input_schema: { type: "object" },
+							},
+						],
+					},
+				},
+				response: {},
+			},
+		];
+
+		// Step 1: Select the best request (should skip Haiku, select Sonnet with tools + system)
+		const selectedRequest = selectBestRequest(mockJsonlData);
+
+		// Verify we selected the Sonnet request
+		expect(selectedRequest.request.body.model).toBe("claude-3-5-sonnet-20241022");
+
+		// Step 2: Extract user message (this is where the bug would occur if not fixed)
+		const userMessage = findAndExtractUserMessage(selectedRequest.request.body.messages);
+
+		// Verify extraction worked with string content
+		expect(userMessage).toBe("Write a haiku about the date");
+
+		// Step 3: Extract system prompt
+		const systemPrompt = extractSystemPrompt(selectedRequest.request.body);
+
+		// Verify system prompt extraction
+		expect(systemPrompt).toBe("You are Claude Code, an AI assistant.");
+
+		// Verify we have tools
+		expect(selectedRequest.request.body.tools).toHaveLength(2);
+	});
+
+	it("handles older Claude Code array content format end-to-end", () => {
+		// Simulate the actual JSONL log data from older Claude Code versions
+		const mockJsonlData: RequestResponsePair[] = [
+			{
+				request: {
+					timestamp: 1,
+					method: "POST",
+					url: "/v1/messages",
+					headers: {},
+					body: {
+						model: "claude-3-haiku-20240307",
+						messages: [
+							{
+								role: "user",
+								content: [
+									{
+										type: "text",
+										text: "Check quota",
+									},
+								],
+							},
+						],
+					},
+				},
+				response: {},
+			},
+			{
+				request: {
+					timestamp: 2,
+					method: "POST",
+					url: "/v1/messages",
+					headers: {},
+					body: {
+						model: "claude-3-5-sonnet-20241022",
+						messages: [
+							{
+								role: "user",
+								content: [
+									{
+										type: "text",
+										text: "Write a haiku about the date",
+									},
+								],
+							},
+						],
+						system: [
+							{
+								type: "text",
+								text: "You are Claude Code, an AI assistant.",
+							},
+						],
+						tools: [
+							{
+								name: "Read",
+								description: "Read a file",
+								input_schema: { type: "object" },
+							},
+						],
+					},
+				},
+				response: {},
+			},
+		];
+
+		// Full extraction flow
+		const selectedRequest = selectBestRequest(mockJsonlData);
+		const userMessage = findAndExtractUserMessage(selectedRequest.request.body.messages);
+		const systemPrompt = extractSystemPrompt(selectedRequest.request.body);
+
+		// Verify everything works with array content
+		expect(selectedRequest.request.body.model).toBe("claude-3-5-sonnet-20241022");
+		expect(userMessage).toBe("Write a haiku about the date");
+		expect(systemPrompt).toBe("You are Claude Code, an AI assistant.");
+		expect(selectedRequest.request.body.tools).toHaveLength(1);
+	});
+
+	it("handles mixed content with multiple text blocks", () => {
+		const mockJsonlData: RequestResponsePair[] = [
+			{
+				request: {
+					timestamp: 1,
+					method: "POST",
+					url: "/v1/messages",
+					headers: {},
+					body: {
+						model: "claude-3-5-sonnet-20241022",
+						messages: [
+							{
+								role: "user",
+								content: [
+									{
+										type: "text",
+										text: "First part",
+									},
+									{
+										type: "text",
+										text: "Second part",
+									},
+								],
+							},
+						],
+						system: [
+							{
+								type: "text",
+								text: "System part 1",
+							},
+							{
+								type: "text",
+								text: "System part 2",
+							},
+						],
+						tools: [
+							{
+								name: "Read",
+								description: "Read a file",
+								input_schema: { type: "object" },
+							},
+						],
+					},
+				},
+				response: {},
+			},
+		];
+
+		const selectedRequest = selectBestRequest(mockJsonlData);
+		const userMessage = findAndExtractUserMessage(selectedRequest.request.body.messages);
+		const systemPrompt = extractSystemPrompt(selectedRequest.request.body);
+
+		// Verify multiple text blocks are joined with newlines
+		expect(userMessage).toBe("First part\nSecond part");
+		expect(systemPrompt).toBe("System part 1\nSystem part 2");
+	});
+
+	it("prioritizes requests with system prompts in E2E flow", () => {
+		const mockJsonlData: RequestResponsePair[] = [
+			{
+				request: {
+					timestamp: 1,
+					method: "POST",
+					url: "/v1/messages",
+					headers: {},
+					body: {
+						model: "claude-3-5-sonnet-20241022",
+						messages: [
+							{
+								role: "user",
+								content: "Test message",
+							},
+						],
+						tools: [
+							{ name: "Tool1", description: "desc", input_schema: { type: "object" } },
+							{ name: "Tool2", description: "desc", input_schema: { type: "object" } },
+							{ name: "Tool3", description: "desc", input_schema: { type: "object" } },
+						],
+					},
+				},
+				response: {},
+			},
+			{
+				request: {
+					timestamp: 2,
+					method: "POST",
+					url: "/v1/messages",
+					headers: {},
+					body: {
+						model: "claude-3-5-sonnet-20241022",
+						messages: [
+							{
+								role: "user",
+								content: "Test message with system",
+							},
+						],
+						system: [
+							{
+								type: "text",
+								text: "You are an AI assistant.",
+							},
+						],
+						tools: [{ name: "Tool1", description: "desc", input_schema: { type: "object" } }],
+					},
+				},
+				response: {},
+			},
+		];
+
+		// Should select request with system prompt even though it has fewer tools
+		const selectedRequest = selectBestRequest(mockJsonlData);
+		const userMessage = findAndExtractUserMessage(selectedRequest.request.body.messages);
+		const systemPrompt = extractSystemPrompt(selectedRequest.request.body);
+
+		expect(selectedRequest.request.body.tools).toHaveLength(1);
+		expect(systemPrompt).toBe("You are an AI assistant.");
+		expect(userMessage).toBe("Test message with system");
+	});
+
+	it("handles edge case with no user message", () => {
+		const mockJsonlData: RequestResponsePair[] = [
+			{
+				request: {
+					timestamp: 1,
+					method: "POST",
+					url: "/v1/messages",
+					headers: {},
+					body: {
+						model: "claude-3-5-sonnet-20241022",
+						messages: [
+							{
+								role: "assistant",
+								content: "Only assistant message",
+							},
+						],
+						tools: [{ name: "Tool1", description: "desc", input_schema: { type: "object" } }],
+					},
+				},
+				response: {},
+			},
+		];
+
+		const selectedRequest = selectBestRequest(mockJsonlData);
+		const userMessage = findAndExtractUserMessage(selectedRequest.request.body.messages);
+
+		// Should return empty string when no user message found
+		expect(userMessage).toBe("");
+	});
+
+	it("handles edge case with empty content array", () => {
+		const mockJsonlData: RequestResponsePair[] = [
+			{
+				request: {
+					timestamp: 1,
+					method: "POST",
+					url: "/v1/messages",
+					headers: {},
+					body: {
+						model: "claude-3-5-sonnet-20241022",
+						messages: [
+							{
+								role: "user",
+								content: [],
+							},
+						],
+						tools: [{ name: "Tool1", description: "desc", input_schema: { type: "object" } }],
+					},
+				},
+				response: {},
+			},
+		];
+
+		const selectedRequest = selectBestRequest(mockJsonlData);
+		const userMessage = findAndExtractUserMessage(selectedRequest.request.body.messages);
+
+		// Should return empty string for empty content array
+		expect(userMessage).toBe("");
+	});
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,12 @@
 #!/usr/bin/env node
 
+import { spawn } from "node:child_process";
 import * as path from "node:path";
 import chalk from "chalk";
 import { parse, quote } from "shell-quote";
 import { extractSystemPrompt, findAndExtractUserMessage } from "./core/content-extractor.js";
 import { filterAndSortTools, hasTools, selectBestRequest } from "./core/request-filter.js";
+import { downloadBinary, isNativeBinary, isNativeBinaryPackage } from "./services/binary-service.js";
 import { exists, readDir, readFile, writeFile } from "./services/file-service.js";
 import {
 	downloadPackage,
@@ -12,11 +14,40 @@ import {
 	getLatestVersion,
 	getVersionReleaseDate,
 } from "./services/npm-service.js";
+import { startProxy } from "./services/proxy-service.js";
 import { exec } from "./services/shell-service.js";
 import { cleanupTempDir, createTempWorkDir } from "./services/temp-service.js";
 import type { RequestResponsePair } from "./types/request.js";
 
 const CCHISTORY_FLAGS = ["--latest", "--binary-path", "--claude-args", "--version", "-v", "--help", "-h"];
+
+/**
+ * Spawn Claude as an async child process.
+ * Must be async (not execSync) so the reverse proxy event loop can process requests.
+ */
+function runClaude(
+	command: string,
+	args: string[],
+	options: { cwd: string; env: Record<string, string> },
+): Promise<{ code: number; stderr: string }> {
+	return new Promise((resolve, reject) => {
+		const child = spawn(command, args, {
+			env: { ...process.env, ...options.env },
+			cwd: options.cwd,
+			stdio: ["pipe", "pipe", "pipe"],
+		});
+
+		let stderr = "";
+		child.stderr?.on("data", (data: Buffer) => {
+			stderr += data.toString();
+		});
+
+		child.on("error", reject);
+		child.on("close", (code) => {
+			resolve({ code: code ?? 1, stderr });
+		});
+	});
+}
 
 async function processVersion(
 	versionOrLabel: string,
@@ -37,151 +68,123 @@ async function processVersion(
 		chalk.blue(`Processing ${customBinaryPath ? `custom binary (${customBinaryPath})` : versionOrLabel}...`),
 	);
 
-	let cliPath: string;
+	let binaryPath: string;
 	let tmpDir: string | undefined;
-	let packageDir: string | undefined;
+	let useNode = false;
 
+	// --- Determine binary path ---
 	if (customBinaryPath) {
-		cliPath = customBinaryPath;
+		binaryPath = customBinaryPath;
+		useNode = !isNativeBinary(customBinaryPath);
 	} else {
 		tmpDir = createTempWorkDir("claude-history");
-		packageDir = path.join(tmpDir, "package");
-		cliPath = path.join(packageDir, "cli.js");
+		const packageDir = path.join(tmpDir, "package");
 
 		downloadPackage(versionOrLabel, tmpDir);
-
 		const tarFile = path.join(tmpDir, `anthropic-ai-claude-code-${versionOrLabel}.tgz`);
 		exec(`tar -xzf ${quote([tarFile])}`, { cwd: tmpDir });
 
-		if (!exists(cliPath)) {
-			console.error(chalk.red(`CLI file not found for version ${versionOrLabel}`));
-			console.error(chalk.gray("Expected path:"), cliPath);
-			console.error(chalk.gray("Package contents:"));
-			try {
-				const packageFiles = readDir(packageDir);
-				packageFiles.forEach((file) => console.error(chalk.gray(`  - ${file}`)));
-			} catch (_e) {
-				console.error(chalk.gray("  Could not list package directory"));
-			}
-			throw new Error(`CLI file not found at ${cliPath}`);
-		}
-	}
-
-	const cliContent = readFile(cliPath);
-
-	const patchResult = { patched: false, content: cliContent };
-	const warningText = "It looks like your version of Claude Code";
-	const warningIndex = cliContent.indexOf(warningText);
-
-	if (warningIndex !== -1) {
-		// Scan backwards from the warning to find "function"
-		let functionIndex = -1;
-		for (let i = warningIndex; i >= 0; i--) {
-			if (cliContent.substring(i, i + 8) === "function") {
-				functionIndex = i;
-				break;
-			}
-		}
-
-		if (functionIndex !== -1) {
-			let openBraceIndex = -1;
-			for (let i = functionIndex; i < cliContent.length; i++) {
-				if (cliContent[i] === "{") {
-					openBraceIndex = i;
-					break;
-				}
-			}
-
-			if (openBraceIndex !== -1) {
-				let braceCount = 1;
-				let closeBraceIndex = -1;
-
-				for (let i = openBraceIndex + 1; i < cliContent.length; i++) {
-					if (cliContent[i] === "{") {
-						braceCount++;
-					} else if (cliContent[i] === "}") {
-						braceCount--;
-						if (braceCount === 0) {
-							closeBraceIndex = i;
-							break;
-						}
+		if (isNativeBinaryPackage(packageDir)) {
+			// Native binary version (≥ 2.1.113) — download platform-specific binary
+			binaryPath = downloadBinary(versionOrLabel, tmpDir);
+			useNode = false;
+		} else {
+			// Old cli.js version
+			binaryPath = path.join(packageDir, "cli.js");
+			if (!exists(binaryPath)) {
+				console.error(chalk.red(`CLI file not found for version ${versionOrLabel}`));
+				console.error(chalk.gray("Expected path:"), binaryPath);
+				console.error(chalk.gray("Package contents:"));
+				try {
+					const packageFiles = readDir(packageDir);
+					for (const file of packageFiles) {
+						console.error(chalk.gray(`  - ${file}`));
 					}
+				} catch (_e) {
+					console.error(chalk.gray("  Could not list package directory"));
 				}
-
-				if (closeBraceIndex !== -1) {
-					const functionDeclaration = cliContent.substring(functionIndex, openBraceIndex + 1);
-					const patchedFunction = `${functionDeclaration} /* Version check disabled */ }`;
-					patchResult.content =
-						cliContent.substring(0, functionIndex) + patchedFunction + cliContent.substring(closeBraceIndex + 1);
-					patchResult.patched = true;
-				}
+				throw new Error(`CLI file not found at ${binaryPath}`);
 			}
+			useNode = true;
 		}
 	}
 
-	if (patchResult.patched) {
-		writeFile(cliPath, patchResult.content);
-	} else if (!customBinaryPath) {
-		console.error(chalk.yellow(`Warning: Could not find version check to patch in version ${versionOrLabel}`));
-		console.error(chalk.gray("This version might not have the version check, continuing anyway..."));
+	// --- Create work directory ---
+	let workDir: string;
+	if (customBinaryPath) {
+		tmpDir = createTempWorkDir("claude-history-custom");
+		workDir = tmpDir;
+	} else {
+		if (!tmpDir) throw new Error("Internal error: tmpDir not initialized");
+		workDir = tmpDir;
 	}
 
 	try {
-		let workDir: string;
-		if (customBinaryPath) {
-			tmpDir = createTempWorkDir("claude-history-custom");
-			workDir = tmpDir;
-		} else {
-			if (!tmpDir) {
-				throw new Error("Internal error: tmpDir not initialized for npm package");
-			}
-			workDir = tmpDir;
-		}
-
-		process.chdir(workDir);
-
-		const claudePathArg = customBinaryPath ? quote([customBinaryPath]) : "./package/cli.js";
-		let additionalArgs = "";
-		if (claudeArgs) {
-			const parsed = parse(claudeArgs);
-			const stringArgs = parsed.filter((entry): entry is string => typeof entry === "string");
-			additionalArgs = quote(stringArgs);
-		}
-		const command = `npx --node-options="--no-warnings" -y @mariozechner/claude-trace --claude-path ${claudePathArg} --no-open --run-with ${additionalArgs}${
-			additionalArgs ? " " : ""
-		}-p "${new Date().toISOString()} is the date. Write a haiku about it."`;
+		// --- Start reverse proxy ---
+		const traceDir = path.join(workDir, ".trace-log");
+		const proxy = await startProxy(traceDir);
 
 		try {
-			exec(command);
-		} catch (error) {
-			console.error(
-				chalk.red(
-					`\nFailed to run claude-trace for ${customBinaryPath ? "custom binary" : `version ${versionOrLabel}`}:`,
-				),
-			);
-			console.error(chalk.gray(`Command: ${command}`));
-			throw error;
+			// --- Build Claude invocation ---
+			const promptArgs = ["-p", `${new Date().toISOString()} is the date. Write a haiku about it.`];
+
+			let additionalArgs: string[] = [];
+			if (claudeArgs) {
+				const parsed = parse(claudeArgs);
+				additionalArgs = parsed.filter((entry): entry is string => typeof entry === "string");
+			}
+
+			const command = useNode ? "node" : binaryPath;
+			const args = useNode ? [binaryPath, ...promptArgs, ...additionalArgs] : [...promptArgs, ...additionalArgs];
+
+			const env = {
+				ANTHROPIC_BASE_URL: `http://127.0.0.1:${proxy.port}`,
+				CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1",
+			};
+
+			if (process.env.DEBUG) {
+				console.log(chalk.gray(`  Command: ${command} ${args.join(" ")}`));
+				console.log(chalk.gray(`  ANTHROPIC_BASE_URL: ${env.ANTHROPIC_BASE_URL}`));
+			}
+
+			// --- Run Claude ---
+			const result = await runClaude(command, args, { cwd: workDir, env });
+			if (result.code !== 0) {
+				console.error(chalk.yellow(`  Claude exited with code ${result.code}`));
+				if (process.env.DEBUG && result.stderr) {
+					console.error(chalk.gray("  stderr:"), result.stderr);
+				}
+			}
+		} finally {
+			await proxy.stop();
 		}
 
-		if (!tmpDir) {
-			throw new Error("Internal error: tmpDir not initialized");
-		}
-
-		const claudeTraceDir = path.join(tmpDir, ".claude-trace");
-		const files = readDir(claudeTraceDir);
-		const jsonlFile = files.find((f) => f.startsWith("log-") && f.endsWith(".jsonl"));
+		// --- Read JSONL log ---
+		const logFiles = readDir(traceDir);
+		const jsonlFile = logFiles.find((f) => f.endsWith(".jsonl"));
 
 		if (!jsonlFile) {
-			throw new Error("No JSONL log file found in .claude-trace directory");
+			throw new Error("No JSONL log file found in trace directory");
 		}
 
-		const jsonlPath = path.join(claudeTraceDir, jsonlFile);
+		const jsonlPath = path.join(traceDir, jsonlFile);
 		const jsonlContent = readFile(jsonlPath);
 		const data: RequestResponsePair[] = jsonlContent
 			.trim()
 			.split("\n")
 			.filter((line) => line.trim())
 			.map((line) => JSON.parse(line));
+
+		if (process.env.DEBUG) {
+			console.log(chalk.gray(`  Found ${data.length} request/response pairs`));
+			for (const pair of data) {
+				console.log(
+					chalk.gray(
+						`  - ${pair.request.body.model || "unknown"} (${pair.request.body.tools?.length || 0} tools)`,
+					),
+				);
+			}
+		}
 
 		const selectedRequest = selectBestRequest(data);
 
@@ -247,7 +250,6 @@ ${toolsFormatted}
 		);
 		throw error;
 	} finally {
-		process.chdir(originalCwd);
 		if (tmpDir) {
 			cleanupTempDir(tmpDir);
 		}

--- a/src/services/binary-service.ts
+++ b/src/services/binary-service.ts
@@ -1,0 +1,141 @@
+/**
+ * Service for downloading and detecting Claude Code native binaries.
+ * Handles the transition from Node.js cli.js to compiled Bun binaries (≥ 2.1.113).
+ */
+
+import { execSync, spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import chalk from "chalk";
+import { quote } from "shell-quote";
+
+const PACKAGE_PREFIX = "@anthropic-ai/claude-code";
+
+/**
+ * Detect if the system uses musl libc (Alpine, etc.)
+ */
+function detectMusl(): boolean {
+	if (process.platform !== "linux") return false;
+	const report = typeof process.report?.getReport === "function" ? process.report.getReport() : null;
+	if (report == null) return false;
+	return (report as Record<string, Record<string, unknown>>).header?.glibcVersionRuntime === undefined;
+}
+
+/**
+ * Get platform key for the current system (matches npm optional dep naming)
+ */
+export function getPlatformKey(): string {
+	const platform = process.platform;
+	let cpu = os.arch();
+
+	if (platform === "linux") {
+		return `linux-${cpu}${detectMusl() ? "-musl" : ""}`;
+	}
+
+	// Rosetta 2: prefer native arm64 binary over x64 under translation
+	if (platform === "darwin" && cpu === "x64") {
+		const r = spawnSync("sysctl", ["-n", "sysctl.proc_translated"], { encoding: "utf8" });
+		if (r.stdout?.trim() === "1") {
+			cpu = "arm64";
+		}
+	}
+
+	return `${platform}-${cpu}`;
+}
+
+/**
+ * Get the npm package name for the current platform's binary
+ */
+export function getPlatformPackageName(): string {
+	return `${PACKAGE_PREFIX}-${getPlatformKey()}`;
+}
+
+/**
+ * Download the platform-specific Claude Code binary for a given version
+ * @param version - Version to download
+ * @param targetDir - Parent directory (binary extracted into targetDir/native-binary/)
+ * @returns Absolute path to the extracted binary
+ */
+export function downloadBinary(version: string, targetDir: string): string {
+	const pkg = getPlatformPackageName();
+	const binaryDir = path.join(targetDir, "native-binary");
+	fs.mkdirSync(binaryDir, { recursive: true });
+
+	console.log(chalk.gray(`  Downloading platform binary ${pkg}@${version}...`));
+
+	try {
+		execSync(`npm pack ${quote([`${pkg}@${version}`])}`, {
+			cwd: binaryDir,
+			stdio: ["pipe", "pipe", "pipe"],
+		});
+	} catch (error) {
+		throw new Error(
+			`Failed to download platform binary ${pkg}@${version}: ${error instanceof Error ? error.message : String(error)}`,
+		);
+	}
+
+	const files = fs.readdirSync(binaryDir);
+	const tarFile = files.find((f) => f.endsWith(".tgz"));
+	if (!tarFile) {
+		throw new Error(`Could not find platform package tarball for ${pkg}@${version}`);
+	}
+
+	execSync(`tar -xzf ${quote([tarFile])}`, {
+		cwd: binaryDir,
+		stdio: ["pipe", "pipe", "pipe"],
+	});
+
+	const binaryName = process.platform === "win32" ? "claude.exe" : "claude";
+	const binaryPath = path.join(binaryDir, "package", binaryName);
+
+	if (!fs.existsSync(binaryPath)) {
+		const packageFiles = fs.readdirSync(path.join(binaryDir, "package"));
+		throw new Error(`Binary not found at ${binaryPath}. Package contents: ${packageFiles.join(", ")}`);
+	}
+
+	fs.chmodSync(binaryPath, 0o755);
+	return binaryPath;
+}
+
+/**
+ * Check if an extracted package uses native binary format (no cli.js)
+ * @param packageDir - Path to extracted npm package directory
+ * @returns true if the package uses native binary format
+ */
+export function isNativeBinaryPackage(packageDir: string): boolean {
+	return !fs.existsSync(path.join(packageDir, "cli.js"));
+}
+
+/**
+ * Detect if a file is a native executable (ELF, Mach-O, PE) vs JavaScript
+ * @param filePath - Path to the file
+ * @returns true if the file is a native binary
+ */
+export function isNativeBinary(filePath: string): boolean {
+	if (filePath.endsWith(".js") || filePath.endsWith(".cjs") || filePath.endsWith(".mjs")) {
+		return false;
+	}
+
+	try {
+		const buf = Buffer.alloc(4);
+		const fd = fs.openSync(filePath, "r");
+		fs.readSync(fd, buf, 0, 4, 0);
+		fs.closeSync(fd);
+
+		// ELF: 7f 45 4c 46
+		if (buf[0] === 0x7f && buf[1] === 0x45 && buf[2] === 0x4c && buf[3] === 0x46) return true;
+		// Mach-O 64-bit: cf fa ed fe
+		if (buf[0] === 0xcf && buf[1] === 0xfa && buf[2] === 0xed && buf[3] === 0xfe) return true;
+		// Mach-O 32-bit: ce fa ed fe
+		if (buf[0] === 0xce && buf[1] === 0xfa && buf[2] === 0xed && buf[3] === 0xfe) return true;
+		// Mach-O universal: fe ed fa cf/ce
+		if (buf[0] === 0xfe && buf[1] === 0xed && buf[2] === 0xfa) return true;
+		// PE (Windows): 4d 5a
+		if (buf[0] === 0x4d && buf[1] === 0x5a) return true;
+
+		return false;
+	} catch {
+		return false;
+	}
+}

--- a/src/services/proxy-service.ts
+++ b/src/services/proxy-service.ts
@@ -1,0 +1,132 @@
+/**
+ * HTTP reverse proxy for intercepting Claude API requests.
+ * Replaces claude-trace — works with both Node.js and native binary versions.
+ */
+
+import * as fs from "node:fs";
+import * as http from "node:http";
+import * as https from "node:https";
+import * as path from "node:path";
+
+const ANTHROPIC_API_HOST = "api.anthropic.com";
+
+export interface ProxyServer {
+	port: number;
+	logPath: string;
+	stop: () => Promise<void>;
+}
+
+/**
+ * Start a reverse proxy that forwards requests to the Anthropic API
+ * and logs request/response pairs as JSONL (matching RequestResponsePair format)
+ * @param logDir - Directory to write the JSONL log file
+ * @returns ProxyServer with port, logPath, and stop function
+ */
+export function startProxy(logDir: string): Promise<ProxyServer> {
+	fs.mkdirSync(logDir, { recursive: true });
+	const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+	const logPath = path.join(logDir, `log-${timestamp}.jsonl`);
+	const logStream = fs.createWriteStream(logPath, { flags: "a" });
+
+	const server = http.createServer((req, res) => {
+		const requestChunks: Buffer[] = [];
+
+		req.on("data", (chunk: Buffer) => {
+			requestChunks.push(chunk);
+		});
+
+		req.on("end", () => {
+			const requestBody = Buffer.concat(requestChunks).toString("utf-8");
+			const requestTimestamp = Date.now();
+
+			// Build forwarding headers — replace host, recalculate content-length
+			const forwardHeaders: Record<string, string | string[] | undefined> = { ...req.headers };
+			delete forwardHeaders.host;
+			delete forwardHeaders["content-length"];
+
+			const options: https.RequestOptions = {
+				hostname: ANTHROPIC_API_HOST,
+				port: 443,
+				path: req.url,
+				method: req.method,
+				headers: {
+					...forwardHeaders,
+					host: ANTHROPIC_API_HOST,
+					"content-length": Buffer.byteLength(requestBody).toString(),
+				},
+			};
+
+			const proxyReq = https.request(options, (proxyRes) => {
+				const responseChunks: Buffer[] = [];
+
+				// Stream response headers and data through immediately
+				res.writeHead(proxyRes.statusCode || 200, proxyRes.headers);
+
+				proxyRes.on("data", (chunk: Buffer) => {
+					responseChunks.push(chunk);
+					res.write(chunk);
+				});
+
+				proxyRes.on("end", () => {
+					const responseBody = Buffer.concat(responseChunks).toString("utf-8");
+
+					let parsedRequest: unknown;
+					let parsedResponse: unknown;
+					try {
+						parsedRequest = JSON.parse(requestBody);
+					} catch {
+						parsedRequest = requestBody;
+					}
+					try {
+						parsedResponse = JSON.parse(responseBody);
+					} catch {
+						// SSE/streaming responses won't parse — store raw string
+						parsedResponse = responseBody;
+					}
+
+					const pair = {
+						request: {
+							timestamp: requestTimestamp,
+							method: req.method || "POST",
+							url: req.url || "/",
+							headers: req.headers as Record<string, string>,
+							body: parsedRequest,
+						},
+						response: parsedResponse,
+					};
+
+					logStream.write(`${JSON.stringify(pair)}\n`);
+					res.end();
+				});
+			});
+
+			proxyReq.on("error", (err) => {
+				console.error(`Proxy forwarding error: ${err.message}`);
+				if (!res.headersSent) {
+					res.writeHead(502);
+				}
+				res.end(`Proxy error: ${err.message}`);
+			});
+
+			proxyReq.write(requestBody);
+			proxyReq.end();
+		});
+	});
+
+	return new Promise((resolve, reject) => {
+		server.on("error", reject);
+		server.listen(0, "127.0.0.1", () => {
+			const addr = server.address() as { port: number };
+			resolve({
+				port: addr.port,
+				logPath,
+				stop: () =>
+					new Promise<void>((resolveStop) => {
+						logStream.end(() => {
+							server.close(() => resolveStop());
+						});
+					}),
+			});
+		});
+	});
+}


### PR DESCRIPTION
This commit improves request selection logic to prioritize system prompts and adds comprehensive support for Claude Code version 2.0.24 and later, which use a different message format.

Request filtering improvements:
- Implemented 3-tier prioritization in selectBestRequest(): a. Requests with both tools AND system prompt (sorted by tool count) b. Requests with tools only (sorted by tool count) c. Any non-Haiku request (final fallback)
- Added filterRequestsWithSystemPrompt() helper function
- Added hasSystemPrompt() utility for validation
- This ensures system prompts are captured even when Claude Code versions have incomplete prompt data

Testing enhancements:
- Added comprehensive integration tests covering end-to-end extraction flow
- Added tests for Claude Code 2.0.24+ string content format
- Added tests for older array content format
- Added tests for system prompt prioritization
- Added 268 new test cases to request-filter.test.ts
- All tests verify both string and array message formats work correctly

Documentation:
- Added Claude Code version compatibility table to README
- Documents version format changes and cchistory support requirements
- Notes unpublished versions (2.0.4, 2.0.6, 2.0.7, 2.0.16)

This change addresses issue #6 where cchistory v1.1.9 failed with Claude Code 2.0.24+ due to the string message format change.
Implemented fix from @marckrenn found here https://github.com/badlogic/cchistory/pull/5#issuecomment-3422658295

---

I tested myself and everything appears to be functioning including with older versions, spot checked version from 2.0.0 to 2.0.24. However I am pretty tired today, so any help testing or reviewing the changes is appreciated, in case I missed anything.